### PR TITLE
Add -r timeout[:interval] option to atf-check.

### DIFF
--- a/atf-sh/atf-check.1
+++ b/atf-sh/atf-check.1
@@ -26,7 +26,7 @@
 .\" OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 .\" IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd June 27, 2014
+.Dd July 31, 2014
 .Dt ATF-CHECK 1
 .Os
 .Sh NAME
@@ -117,6 +117,12 @@ as a shell command line, executing it with the system shell defined by
 .Va ATF_SHELL .
 You should avoid using this flag if at all possible to prevent shell quoting
 issues.
+.It Fl r Ar timeout[:interval]
+Repeats failed checks until the
+.Ar timeout
+(in seconds) expires. If unspecified, the default
+.Ar interval
+(in milliseconds) is 50 ms. This can be used to wait for syslog output.
 .El
 .Sh EXIT STATUS
 .Nm
@@ -146,4 +152,9 @@ atf-check -s signal:sigsegv my_program
 
 # Combined checks
 atf-check -o match:foo -o not-match:bar echo foo baz
+
+# Wait 5 seconds for a line to show up in messages
+logger "testing 123"
+atf-check -o ignore -e ignore -s exit:0 -r 5 \e
+    -x grep "testing 123" /var/log/messages
 .Ed

--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -33,6 +33,7 @@ extern "C" {
 
 #include <limits.h>
 #include <signal.h>
+#include <stdint.h>
 #include <unistd.h>
 }
 
@@ -57,6 +58,10 @@ extern "C" {
 #include "atf-c++/detail/process.hpp"
 #include "atf-c++/detail/sanity.hpp"
 #include "atf-c++/detail/text.hpp"
+
+static const useconds_t seconds_in_useconds = (1000 * 1000);
+static const useconds_t mseconds_in_useconds = 1000;
+static const useconds_t useconds_in_nseconds = 1000;
 
 // ------------------------------------------------------------------------
 // Auxiliary functions.
@@ -163,6 +168,33 @@ public:
 };
 
 } // anonymous namespace
+
+static useconds_t
+get_monotonic_useconds(void)
+{
+    struct timespec ts;
+    useconds_t res;
+    int rc;
+
+    rc = clock_gettime(CLOCK_MONOTONIC, &ts);
+    if (rc != 0)
+        throw std::runtime_error("clock_gettime: " +
+            std::string(strerror(errno)));
+
+    res = ts.tv_sec * seconds_in_useconds;
+    res += ts.tv_nsec / useconds_in_nseconds;
+    return res;
+}
+
+static bool
+timo_expired(useconds_t timeout)
+{
+
+    if (get_monotonic_useconds() >= timeout)
+        return true;
+    return false;
+}
+
 
 static int
 parse_exit_code(const std::string& str)
@@ -306,6 +338,54 @@ parse_output_check_arg(const std::string& arg)
         throw atf::application::usage_error("Invalid output checker");
 
     return output_check(type, negated, arg.substr(delimiter + 1));
+}
+
+static void
+parse_repeat_check_arg(const std::string& arg, useconds_t *m_timo,
+    useconds_t *m_interval)
+{
+    const std::string::size_type delimiter = arg.find(':');
+    const bool has_interval = (delimiter != std::string::npos);
+    const std::string timo_str = arg.substr(0, delimiter);
+
+    long l;
+    char *end;
+
+    // There is no reason this couldn't be a non-integer number of seconds,
+    // this was just easy to do for now.
+    errno = 0;
+    l = strtol(timo_str.c_str(), &end, 10);
+    if (errno == ERANGE)
+        throw atf::application::usage_error("Bogus timeout in seconds");
+    else if (errno != 0)
+        throw atf::application::usage_error("Timeout must be a number");
+
+    if (*end != 0)
+        throw atf::application::usage_error("Timeout must be a number");
+
+    *m_timo = get_monotonic_useconds() + (l * seconds_in_useconds);
+    *m_interval = 50 * mseconds_in_useconds;
+
+    if (!has_interval)
+        return;
+
+    const std::string intv_str = arg.substr(delimiter + 1, std::string::npos);
+
+    // Same -- this could be non-integer milliseconds.
+    errno = 0;
+    l = strtol(intv_str.c_str(), &end, 10);
+    if (errno == ERANGE)
+        throw atf::application::usage_error(
+            "Bogus repeat interval in milliseconds");
+    else if (errno != 0)
+        throw atf::application::usage_error(
+            "Repeat interval must be a number");
+
+    if (*end != 0)
+        throw atf::application::usage_error(
+            "Repeat interval must be a number");
+
+    *m_interval = l * mseconds_in_useconds;
 }
 
 static
@@ -698,6 +778,10 @@ namespace {
 
 class atf_check : public atf::application::app {
     bool m_xflag;
+    bool m_rflag;
+
+    useconds_t m_timo;
+    useconds_t m_interval;
 
     std::vector< status_check > m_status_checks;
     std::vector< output_check > m_stdout_checks;
@@ -725,7 +809,8 @@ const char* atf_check::m_description =
 
 atf_check::atf_check(void) :
     app(m_description, "atf-check(1)"),
-    m_xflag(false)
+    m_xflag(false),
+    m_rflag(false)
 {
 }
 
@@ -769,6 +854,8 @@ atf_check::specific_options(void)
                 "one of: empty ignore file:<path> inline:<val> match:regexp "
                 "save:<path>"));
     opts.insert(option('x', "", "Execute command as a shell command"));
+    opts.insert(option('r', "timeout[:interval]", "Repeat failed check until "
+                "the timeout expires."));
 
     return opts;
 }
@@ -793,6 +880,11 @@ atf_check::process_option(int ch, const char* arg)
         m_xflag = true;
         break;
 
+    case 'r':
+        m_rflag = true;
+        parse_repeat_check_arg(arg, &m_timo, &m_interval);
+        break;
+
     default:
         UNREACHABLE;
     }
@@ -806,9 +898,6 @@ atf_check::main(void)
 
     int status = EXIT_FAILURE;
 
-    std::auto_ptr< atf::check::check_result > r =
-        m_xflag ? execute_with_shell(m_argv) : execute(m_argv);
-
     if (m_status_checks.empty())
         m_status_checks.push_back(status_check(sc_exit, false, EXIT_SUCCESS));
     else if (m_status_checks.size() > 1) {
@@ -821,12 +910,23 @@ atf_check::main(void)
     if (m_stderr_checks.empty())
         m_stderr_checks.push_back(output_check(oc_empty, false, ""));
 
-    if ((run_status_checks(m_status_checks, *r) == false) ||
-        (run_output_checks(*r, "stderr") == false) ||
-        (run_output_checks(*r, "stdout") == false))
-        status = EXIT_FAILURE;
-    else
-        status = EXIT_SUCCESS;
+    do {
+        std::auto_ptr< atf::check::check_result > r =
+            m_xflag ? execute_with_shell(m_argv) : execute(m_argv);
+
+        if ((run_status_checks(m_status_checks, *r) == false) ||
+            (run_output_checks(*r, "stderr") == false) ||
+            (run_output_checks(*r, "stdout") == false))
+            status = EXIT_FAILURE;
+        else
+            status = EXIT_SUCCESS;
+
+        if (m_rflag && status == EXIT_FAILURE) {
+            m_rflag = !timo_expired(m_timo);
+            if (m_rflag)
+                usleep(m_interval);
+        }
+    } while (m_rflag && status == EXIT_FAILURE);
 
     return status;
 }


### PR DESCRIPTION
Sponsored by:   EMC / Isilon storage division

[PR notes, not for commit log:

I'm mostly soliciting feedback, I don't expect this to be merged as-is (although that would be fine with me). Let me know why it's horrible and I can try and clean it up.

I looked a little bit at trying to make this less noisy (currently each iteration produces the failed status, stdout, and stderr output), but lots of `atf-check.cpp` is hardcoded to write directly out to `std::cout` or `std::cerr`. Changing this would be pretty invasive, and doing it appropriately is probably beyond my C++ abilities.

Doing it right should just be a matter of directing `atf-check.cpp` output to a `stringstream` for each of stdout, stderr; on repeat (the `if ()` clause where we `usleep()`), clear the buffers with `.str("")` and `.clear()`. On exiting the `do { ... } while (...)` loop, print the contents of each buffer to its appropriate stream. This won't interleave exactly the same, but I hope we were not relying on that.

Thanks for taking a look.]
