### PR TITLE
Raise the sleep from 1 second to 5 seconds in flush_stdout_on_timeout_body(..)

### DIFF
--- a/atf-sh/atf_check_test.sh
+++ b/atf-sh/atf_check_test.sh
@@ -170,7 +170,7 @@ flush_stdout_on_timeout_body()
     "$(atf_get_srcdir)/misc_helpers" -s "$(atf_get_srcdir)" atf_check_timeout \
         >out 2>err &
     pid="${!}"
-    sleep 1
+    sleep 5
     kill "${pid}"
 
     grep 'Executing command.*true' out \


### PR DESCRIPTION
Raise the timeout from 1 second to 5 seconds to ensure that sleep 42
will show up in the output from the misc helpers

This should help sufficiently taxed systems so the test does not
intermittently fail when run on them

PR: 197060
