### PR TITLE
Fix ATF_REQUIRE_EQ() for gcc 4.9

### DIFF
--- a/atf-c++/macros.hpp
+++ b/atf-c++/macros.hpp
@@ -111,7 +111,8 @@
             std::ostringstream atfu_ss; \
             atfu_ss << "Line " << __LINE__ << ": " \
                     << #expected << " != " << #actual \
-                    << " (" << (expected) << " != " << (actual) << ")"; \
+                    << " (" << (expected) << " != " << \
+                    static_cast<__typeof(expected)>(actual) << ")"; \
             atf::tests::tc::fail(atfu_ss.str()); \
         } \
     } while (false)


### PR DESCRIPTION
The fix is to cast the NULL value to the specific pointer type ATF is
testing against.

In C++ mode, ATF_REQUIRE_EQ will attempt to output the value of NULL
onto a std::ostringstream, but this has become ambiguous in C++11.

Before C++11, NULL is defined as 0, e.g. plain zero, and it will
therefore be printed as an integer "0".  In C++11 and later, NULL is
defined as the keyword nullptr, e.g. the null pointer literal.  Since
the null pointer can be converted to any other pointer type, and there
are many different operators defined in C++ to output those operators,
the call is ambiguous, and must be resolved by the developer.

Submitted by: Dimitry Andric dim@FreeBSD.org
