### PR TITLE
atf_tp_get_tc's prototype doesn't allow the returned array to be free…

### DIFF
--- a/atf-c/detail/tp_main.c
+++ b/atf-c/detail/tp_main.c
@@ -248,7 +248,7 @@ static
 void
 list_tcs(const atf_tp_t *tp)
 {
-    const atf_tc_t *const *tcs;
+    const atf_tc_t **tcs;
     const atf_tc_t *const *tcsptr;
 
     printf("Content-Type: application/X-atf-tp; version=\"1\"\n\n");

--- a/atf-c/tp.c
+++ b/atf-c/tp.c
@@ -139,7 +139,7 @@ atf_tp_get_tc(const atf_tp_t *tp, const char *id)
     return tc;
 }
 
-const atf_tc_t *const *
+const atf_tc_t **
 atf_tp_get_tcs(const atf_tp_t *tp)
 {
     const atf_tc_t **array;

--- a/atf-c/tp.h
+++ b/atf-c/tp.h
@@ -50,7 +50,7 @@ void atf_tp_fini(atf_tp_t *);
 char **atf_tp_get_config(const atf_tp_t *);
 bool atf_tp_has_tc(const atf_tp_t *, const char *);
 const struct atf_tc *atf_tp_get_tc(const atf_tp_t *, const char *);
-const struct atf_tc *const *atf_tp_get_tcs(const atf_tp_t *);
+const struct atf_tc **atf_tp_get_tcs(const atf_tp_t *);
 
 /* Modifiers. */
 atf_error_t atf_tp_add_tc(atf_tp_t *, struct atf_tc *);


### PR DESCRIPTION
…d.  relax the const constraints to allow the array to be freed.