### PR TITLE
tp_test.c: fix compilation on Solaris

### DIFF
--- a/atf-c/tp_test.c
+++ b/atf-c/tp_test.c
@@ -23,6 +23,7 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  */
 
+#include "config.h"
 #include "atf-c/tp.h"
 
 #include <string.h>

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ AC_CONFIG_SRCDIR([atf-c.h])
 AC_CONFIG_TESTDIR([bootstrap])
 
 AC_CANONICAL_TARGET
+AC_USE_SYSTEM_EXTENSIONS
 
 AM_INIT_AUTOMAKE([1.9 check-news foreign subdir-objects -Wall])
 


### PR DESCRIPTION
On Solaris, getopt(3) is in stdio.h.