### PR TITLE
atf-sh: fix a gcc-8 compile warning in the atf shell

### DIFF
--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -216,7 +216,7 @@ parse_signal(const std::string& str)
     if (signo == INT_MIN) {
         try {
             return atf::text::to_type< int >(str);
-        } catch (std::runtime_error) {
+        } catch (std::runtime_error&) {
             throw atf::application::usage_error("Invalid signal name or number "
                 "in -s option");
         }


### PR DESCRIPTION
atf-sh/atf-check.cpp: In function ‘int parse_signal(const string&)’:
atf-sh/atf-check.cpp:219:23: error: catching polymorphic type ‘class std::runtime_error’ by value [-Werror=catch-value=]
         } catch (std::runtime_error) {
                       ^~~~~~~~~~~~~
cc1plus: all warnings being treated as errors