### PR TITLE
Fix a typo when describing `ATF_REQUIRE_THROW_RE`

### DIFF
--- a/atf-c++/atf-c++.3
+++ b/atf-c++/atf-c++.3
@@ -403,7 +403,7 @@ in the collection.
 takes the name of an exception and a statement and raises a failure if
 the statement does not throw the specified exception.
 .Fn ATF_REQUIRE_THROW_RE
-takes the name of an exception, a regular expresion and a statement and raises a
+takes the name of an exception, a regular expression and a statement, and raises a
 failure if the statement does not throw the specified exception and if the
 message of the exception does not match the regular expression.
 .Pp


### PR DESCRIPTION
`expresion` should be `expression`.

While here, add an additional comma to aid with sentence flow.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>