### PR TITLE
Fixed error in atf-c/utils.h header.

### DIFF
--- a/atf-c/utils.h
+++ b/atf-c/utils.h
@@ -26,6 +26,7 @@
 #if !defined(ATF_C_UTILS_H)
 #define ATF_C_UTILS_H
 
+#include <sys/types.h>
 #include <stdbool.h>
 #include <unistd.h>
 


### PR DESCRIPTION
In this file, pid_t is used, so we need to include sys/types.h where this type is defined.