### PR TITLE
Fix use after free in execute_with_shell.

### DIFF
--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -434,9 +434,10 @@ std::auto_ptr< atf::check::check_result >
 execute_with_shell(char* const* argv)
 {
     const std::string cmd = flatten_argv(argv);
-
+    const std::string shell = atf::env::get("ATF_SHELL", ATF_SHELL);
     const char* sh_argv[4];
-    sh_argv[0] = atf::env::get("ATF_SHELL", ATF_SHELL).c_str();
+
+    sh_argv[0] = shell.c_str();
     sh_argv[1] = "-c";
     sh_argv[2] = cmd.c_str();
     sh_argv[3] = NULL;


### PR DESCRIPTION
The temporary string returned by atf::env::get would be used outside its statement, which is invalid and cause undefined behavior.  Copy it to a local variable to avoid the issue.

Fixes: https://github.com/freebsd/atf/issues/26
Fixes: https://github.com/freebsd/kyua/issues/223

Reported-by: Ruslan Bukin <br@bsdpad.com>