### PR TITLE
Update URLs to reference freebsd org instead of jmmv's personal account

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -109,7 +109,7 @@ does not depend on any internal details of atf-c++ any longer.
 * Project hosting moved from Google Code (as a subproject of Kyua) to
   GitHub (as a first-class project).  The main reason for the change is
   the suppression of binary downloads in Google Code on Jan 15th, 2014.
-  See https://github.com/jmmv/atf/
+  See https://github.com/freebsd/atf/
 
 * Removed builtin help from atf-sh(1) and atf-check(1) for simplicity
   reasons.  In other words, their -h option is gone.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ interface** to allow both humans and automation to run the tests.
 
 ATF-based test programs **rely on an execution engine** to be run and
 this execution engine is *not* shipped with ATF.
-**[Kyua](https://github.com/jmmv/kyua/) is the engine of choice.**
+**[Kyua](https://github.com/freebsd/kyua/) is the engine of choice.**
 
 ## Download
 

--- a/admin/travis-install-deps.sh
+++ b/admin/travis-install-deps.sh
@@ -55,7 +55,7 @@ install_from_github() {
 
     local distname="${name}-${release}"
 
-    local baseurl="https://github.com/jmmv/${name}"
+    local baseurl="https://github.com/freebsd/${name}"
     wget --no-check-certificate \
         "${baseurl}/releases/download/${distname}/${distname}.tar.gz"
     tar -xzvf "${distname}.tar.gz"
@@ -93,7 +93,7 @@ install_from_bintray() {
             exit 1
             ;;
     esac
-    wget "http://dl.bintray.com/jmmv/kyua/${name}" || return 1
+    wget "http://dl.bintray.com/freebsd/kyua/${name}" || return 1
     sudo tar -xzvp -C / -f "${name}"
     rm -f "${name}"
 }


### PR DESCRIPTION
This finishes documenting the transition for multiple kyua-related
projects from @jmmv's personal GitHub account to the @freebsd github
org.