### PR TITLE
admin/make-release.sh: automate release creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ config.status
 configure
 installcheck.log
 libtool
+releases
 stamp-h1
 testsuite.log

--- a/admin/make-release.exclude
+++ b/admin/make-release.exclude
@@ -1,0 +1,11 @@
+*/.cirrus.yml
+*/.github/*
+*/.gitignore
+*/.travis.yml
+*/admin*
+*/autom4te.cache/*
+*/m4/libtool.m4
+*/m4/ltoptions.m4
+*/m4/ltsugar.m4
+*/m4/ltversion.m4
+*/m4/lt~obsolete.m4

--- a/admin/make-release.sh
+++ b/admin/make-release.sh
@@ -1,41 +1,31 @@
 #!/bin/sh
 #
-# Create a release from `ref`.
+# Create release artifacts from a release tag.
 #
 # Example:
 # 	./admin/make-release.sh atf-0.23
 
 set -eux
 
-ref=$1
+tag=$1
 
 cd "$(dirname "$(dirname "$0")")"
 
 mkdir -p releases
 release_root=$(realpath releases)
 
-release_dir="${release_root}/${ref}"
-release_artifact="${release_root}/${ref}.tar.gz"
+release_dir="${release_root}/${tag}"
+release_artifact="${release_root}/${tag}.tar.gz"
 
 rm -Rf "${release_dir}"
 mkdir -p "${release_dir}"
-git archive "${ref}" | tar xzvf - -C "${release_dir}"
+git archive "${tag}" | tar xzvf - -C "${release_dir}"
 cd "${release_dir}"
 autoreconf -is
 cd "${release_root}"
 bsdtar \
-    --exclude '*/.cirrus.yml' \
-    --exclude '*/.github/*' \
-    --exclude '*/.gitignore' \
-    --exclude '*/.travis.yml' \
-    --exclude '*/admin*' \
-    --exclude '*/autom4te.cache/*' \
-    --exclude '*/m4/libtool.m4' \
-    --exclude '*/m4/ltoptions.m4' \
-    --exclude '*/m4/ltsugar.m4' \
-    --exclude '*/m4/ltversion.m4' \
-    --exclude '*/m4/lt~obsolete.m4' \
+    --exclude-from=${release_dir}/admin/make-release.exclude \
     --uname "" --gname "" \
     --uid 0 --gid 0 \
-    -cvpzf "${release_artifact}" "${ref}"
+    -cvpzf "${release_artifact}" "${tag}"
 sha256 "${release_artifact##*/}" > "${release_artifact}.sha256"

--- a/admin/make-release.sh
+++ b/admin/make-release.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Create a release from `ref`.
+#
+# Example:
+# 	./admin/make-release.sh atf-0.23
+
+set -eux
+
+ref=$1
+
+cd "$(dirname "$(dirname "$0")")"
+
+mkdir -p releases
+release_root=$(realpath releases)
+
+release_dir="${release_root}/${ref}"
+release_artifact="${release_root}/${ref}.tar.gz"
+
+rm -Rf "${release_dir}"
+mkdir -p "${release_dir}"
+git archive "${ref}" | tar xzvf - -C "${release_dir}"
+cd "${release_dir}"
+autoreconf -is
+cd "${release_root}"
+bsdtar \
+    --exclude '*/.cirrus.yml' \
+    --exclude '*/.github/*' \
+    --exclude '*/.gitignore' \
+    --exclude '*/.travis.yml' \
+    --exclude '*/admin*' \
+    --exclude '*/autom4te.cache/*' \
+    --exclude '*/m4/libtool.m4' \
+    --exclude '*/m4/ltoptions.m4' \
+    --exclude '*/m4/ltsugar.m4' \
+    --exclude '*/m4/ltversion.m4' \
+    --exclude '*/m4/lt~obsolete.m4' \
+    --uname "" --gname "" \
+    --uid 0 --gid 0 \
+    -cvpzf "${release_artifact}" "${ref}"
+sha256 "${release_artifact##*/}" > "${release_artifact}.sha256"


### PR DESCRIPTION
This does the absolute bare minimum to produce a release.
    
This logic best resembles the expectations for legacy (pre-0.22) releases
of ATF.
    
Various files are omitted as they are not required in order to build
from a full `autoreconf`'ed source distribution.