### PR TITLE
Fix leak

### DIFF
--- a/atf-c++/tests.cpp
+++ b/atf-c++/tests.cpp
@@ -272,6 +272,7 @@ impl::tc::get_md_vars(void)
         char **ptr;
         for (ptr = array; *ptr != NULL; ptr += 2)
             vars[*ptr] = *(ptr + 1);
+        atf_utils_free_charpp(array);
     } catch (...) {
         atf_utils_free_charpp(array);
         throw;


### PR DESCRIPTION
std::string creates a copy of the string used for initialization which needs to be freed manually.