### PR TITLE
atf_check: fix std::length_error thrown from temp_file

### DIFF
--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -118,8 +118,8 @@ public:
         const atf::fs::path file = atf::fs::path(
             atf::env::get("TMPDIR", "/tmp")) / pattern;
 
-        std::vector<char> buf(file.str().begin(), file.str().end());
-        buf.push_back('\0');
+        std::string file_s = file.str();
+        std::vector<char> buf(file_s.begin(), file_s.end() + 1);
 
         m_fd = ::mkstemp(buf.data());
         if (m_fd == -1)


### PR DESCRIPTION
The previous logic used 2 separate calls to `atf::fs::path::str()` when constructing a `std::vector<char>` to pass to `mkstemp(..)`. This in turn caused grief with how data copying is done in atf-c(3), etc, as the prior code computed the length of the path of an internal buffer in `atf_dynstr` structs.

Moreover, the code was manually appending a nul char, which was unnecessary when making the valid assumption that `std::string` is a nul-terminated string.

The new code convert the path to an `std::string` once, includes the existing nul char in the buffer, then passes it to mkstemp(3) instead. The code works properly now.

Closes:	#76