### PR TITLE
Update the version to 0.23

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,11 +1,16 @@
 Major changes between releases                  Automated Testing Framework
 ===========================================================================
 
-Changes in version 0.22
+Changes in version 0.23
 ***********************
 
 STILL UNDER DEVELOPMENT; NOT RELEASED YET.
 DON'T FORGET TO BUMP THE -version-info PRE-RELEASE IF NECESSARY!
+
+Changes in version 0.22
+***********************
+
+Released on November 25th, 2024.
 
 * Issue #23: Fix double-free triggered by atf_map_insert in low memory
   scenarios, caused by an overlook in the atf_list code.

--- a/NEWS
+++ b/NEWS
@@ -10,14 +10,36 @@ DON'T FORGET TO BUMP THE -version-info PRE-RELEASE IF NECESSARY!
 * Issue #23: Fix double-free triggered by atf_map_insert in low memory
   scenarios, caused by an overlook in the atf_list code.
 
-* Issue #29: Fixed various typos and formatting errors in manual pages.
-
 * Issue #31: Added require.progs metadata properties to the tests that
   need a compiler to run.
 
 * Added the atf_check_not_equal function to atf-sh to check for
   unequal values.
 
+* Add `-r timeout` flag to `atf-check`.
+
+* Open results files before executing tests to fix an issue ATF tests that
+  adjust the processes' Capsicum rights as part of the testcase(s)
+  executed.
+
+* Add Cirrus CI integration for FreeBSD CI/CD support.
+
+* Address compilation issues on OpenSolaris distributions.
+
+* Replace `auto_array` with `std::vector` (fixes modern C++ compliance).
+
+* Replace `auto_ptr` with `std::shared_ptr` (fixes modern C++ compliance).
+
+* Update autotools idioms and requirements. The minimum required version of
+  autoconf is now 2.68.
+
+* Always define CPP to fix use of ATF_BUILD_CPP when the user did not
+  define CPP when invoking the configure script.
+
+### General fixes
+
+* Fix various typos and formatting errors in manual pages and markdown
+  documents.
 
 Changes in version 0.21
 ***********************

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ dnl -----------------------------------------------------------------------
 dnl Initialize the GNU build system.
 dnl -----------------------------------------------------------------------
 
-AC_INIT([Automated Testing Framework], [0.22],
+AC_INIT([Automated Testing Framework], [0.23],
         [atf-discuss@googlegroups.com], [atf],
         [https://github.com/jmmv/atf/])
 AC_PREREQ([2.65])


### PR DESCRIPTION
- Pull in NEWS-related changes from the atf-0.22 tag.
- Bump the software version to 0.23.