### PR TITLE
Revert "atf-check.cpp: remove unneeded copying into vector"

### DIFF
--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -118,14 +118,16 @@ public:
         const atf::fs::path file = atf::fs::path(
             atf::env::get("TMPDIR", "/tmp")) / pattern;
 
-        auto file_s = file.str();
-        m_fd = ::mkstemp(file_s.data());
+        std::string file_s = file.str();
+        std::vector<char> buf(file_s.begin(), file_s.end() + 1);
+
+        m_fd = ::mkstemp(buf.data());
         if (m_fd == -1)
             throw atf::system_error("atf_check::temp_file::temp_file(" +
-                                    file_s + ")", "mkstemp(3) failed",
+                                    file.str() + ")", "mkstemp(3) failed",
                                     errno);
 
-        m_path.reset(new atf::fs::path(file_s.data()));
+        m_path.reset(new atf::fs::path(buf.data()));
     }
 
     ~temp_file(void)


### PR DESCRIPTION
This results in a compiler error on MacOS (at least).

`mkstemp(..)` acts on the buffer, so `std::string::data()` can't be used (the latter returns a const char* value).

Reverts freebsd/atf#89