### PR TITLE
Mark the "descr" metadata property "Optional"

### DIFF
--- a/doc/atf-test-case.4
+++ b/doc/atf-test-case.4
@@ -22,7 +22,7 @@
 .\" IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 .\" OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 .\" IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.Dd July 3, 2015
+.Dd December 26, 2024
 .Dt ATF-TEST-CASE 4
 .Os
 .Sh NAME
@@ -153,7 +153,7 @@ The following metadata properties can be exposed via the test case's head:
 .Bl -tag -width requireXmachineXX
 .It descr
 Type: textual.
-Required.
+Optional.
 .Pp
 A brief textual description of the test case's purpose.
 Will be shown to the user in reports.


### PR DESCRIPTION
As noted by the reporter, the "descr" metadata property was made
optional back in the 0.8 release (af4059b214b3ee2d790cd929d696083eb244bcb8 to be specific). Update the
documentation posthumously per the code change.

Closes:	#63
Reported by:	Roland Illig (@rillig)