### PR TITLE
configure.ac: Update mailing list and repo URL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,8 +28,8 @@ dnl Initialize the GNU build system.
 dnl -----------------------------------------------------------------------
 
 AC_INIT([Automated Testing Framework], [0.23],
-        [atf-discuss@googlegroups.com], [atf],
-        [https://github.com/jmmv/atf/])
+        [freebsd-testing@freebsd.org], [atf],
+        [https://github.com/freebsd/atf/])
 AC_PREREQ([2.65])
 AC_COPYRIGHT([Copyright (c) 2007-2012 The NetBSD Foundation, Inc.])
 AC_DEFINE([PACKAGE_COPYRIGHT],


### PR DESCRIPTION
We need to correct this outdated information.

Furthermore, I think the copyright notices in `configure.ac` also need to be updated. But as I don't have any background knowledge of this project's history, someone else should update it instead.