### PR TITLE
Fix build on Solaris

### DIFF
--- a/atf-c/tp_test.c
+++ b/atf-c/tp_test.c
@@ -25,6 +25,7 @@
 
 #include "atf-c/tp.h"
 
+#include <stdio.h>
 #include <string.h>
 #include <unistd.h>
 


### PR DESCRIPTION
On Solaris, getopt(3) is declared in stdio.h.