### PR TITLE
NEWS: Switched to unique_ptr, not shared_ptr

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -60,7 +60,7 @@ Released on November 25th, 2024.
 
 * Replace `auto_array` with `std::vector` (fixes modern C++ compliance).
 
-* Replace `auto_ptr` with `std::shared_ptr` (fixes modern C++ compliance).
+* Replace `auto_ptr` with `std::unique_ptr` (fixes modern C++ compliance).
 
 * Update autotools idioms and requirements. The minimum required version of
   autoconf is now 2.68.


### PR DESCRIPTION
Make NEWS match the change made in commit f053ab687f6e ("Replace auto_ptr with unique_ptr")