### PR TITLE
Widen our process status capabilties

### DIFF
--- a/atf-c/detail/process.h
+++ b/atf-c/detail/process.h
@@ -28,6 +28,7 @@
 
 #include <sys/types.h>
 
+#include <signal.h>
 #include <stdbool.h>
 
 #include <atf-c/detail/fs.h>
@@ -76,7 +77,7 @@ int atf_process_stream_type(const atf_process_stream_t *);
  * --------------------------------------------------------------------- */
 
 struct atf_process_status {
-    int m_status;
+    siginfo_t m_info;
 };
 typedef struct atf_process_status atf_process_status_t;
 

--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -207,12 +207,12 @@ parse_exit_code(const std::string& str)
 {
     try {
         const int value = atf::text::to_type< int >(str);
-        if (value < 0 || value > 255)
+        if (value < INT_MIN || value > INT_MAX)
             throw std::runtime_error("Unused reason");
         return value;
     } catch (const std::runtime_error&) {
         throw atf::application::usage_error("Invalid exit code for -s option; "
-            "must be an integer in range 0-255");
+            "must be an integer in range [%d, %d]", INT_MIN, INT_MAX);
     }
 }
 

--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -73,12 +73,14 @@ struct status_check {
     status_check_t type;
     bool negated;
     int value;
+    bool empty;
 
     status_check(const status_check_t& p_type, const bool p_negated,
-                 const int p_value) :
+                 const int p_value, const bool p_empty) :
         type(p_type),
         negated(p_negated),
-        value(p_value)
+        value(p_value),
+        empty(p_empty)
     {
     }
 };
@@ -273,6 +275,7 @@ parse_status_check_arg(const std::string& arg)
     const std::string value_str = (
         delimiter == std::string::npos ? "" : arg.substr(delimiter + 1));
     int value;
+    bool empty = false;
 
     status_check_t type;
     if (action == "eq") {
@@ -284,9 +287,10 @@ parse_status_check_arg(const std::string& arg)
         value = parse_exit_code(value_str);
     } else if (action == "exit") {
         type = sc_exit;
-        if (value_str.empty())
+        if (value_str.empty()) {
             value = INT_MIN;
-        else
+            empty = true;
+        } else
             value = parse_exit_code(value_str);
     } else if (action == "ignore") {
         if (negated)
@@ -302,14 +306,15 @@ parse_status_check_arg(const std::string& arg)
         value = parse_exit_code(value_str);
     } else if (action == "signal") {
         type = sc_signal;
-        if (value_str.empty())
+        if (value_str.empty()) {
             value = INT_MIN;
-        else
+            empty = true;
+        } else
             value = parse_signal(value_str);
     } else
         throw atf::application::usage_error("Invalid status checker");
 
-    return status_check(type, negated, value);
+    return status_check(type, negated, value, empty);
 }
 
 static
@@ -605,7 +610,7 @@ run_status_check(const status_check& sc, const atf::check::check_result& cr)
     bool result;
 
     if (sc.type == sc_exit) {
-        if (cr.exited() && sc.value != INT_MIN) {
+        if (cr.exited() && !sc.empty) {
             const int status = cr.exitcode();
 
             if (!sc.negated && sc.value != status) {
@@ -620,7 +625,7 @@ run_status_check(const status_check& sc, const atf::check::check_result& cr)
                 result = false;
             } else
                 result = true;
-        } else if (cr.exited() && sc.value == INT_MIN) {
+        } else if (cr.exited() && sc.empty) {
             result = true;
         } else {
             std::cerr << "Fail: program did not exit cleanly\n";
@@ -629,7 +634,7 @@ run_status_check(const status_check& sc, const atf::check::check_result& cr)
     } else if (sc.type == sc_ignore) {
         result = true;
     } else if (sc.type == sc_signal) {
-        if (cr.signaled() && sc.value != INT_MIN) {
+        if (cr.signaled() && !sc.empty) {
             const int status = cr.termsig();
 
             if (!sc.negated && sc.value != status) {
@@ -643,7 +648,7 @@ run_status_check(const status_check& sc, const atf::check::check_result& cr)
                 result = false;
             } else
                 result = true;
-        } else if (cr.signaled() && sc.value == INT_MIN) {
+        } else if (cr.signaled() && sc.empty) {
             result = true;
         } else {
             std::cerr << "Fail: program did not receive a signal\n";
@@ -909,9 +914,10 @@ atf_check::main(void)
 
     int status = EXIT_FAILURE;
 
-    if (m_status_checks.empty())
-        m_status_checks.push_back(status_check(sc_exit, false, EXIT_SUCCESS));
-    else if (m_status_checks.size() > 1) {
+    if (m_status_checks.empty()) {
+        m_status_checks.push_back(status_check(sc_exit, false, EXIT_SUCCESS,
+            false));
+    } else if (m_status_checks.size() > 1) {
         // TODO: Remove this restriction.
         throw atf::application::usage_error("Cannot specify -s more than once");
     }

--- a/atf-sh/atf-check_test.sh
+++ b/atf-sh/atf-check_test.sh
@@ -70,13 +70,12 @@ sflag_eq_ne_body()
 {
     h_pass "true" -s eq:0
     h_pass "false" -s ne:0
-    h_pass "exit 255" -s eq:255
+    h_pass "exit 2147483647" -s eq:2147483647
     h_pass "exit 0" -s ne:255
 
-    h_fail "exit 256" -s eq:256
+    h_fail "exit 2147483648" -s eq:2147483648
     h_fail "exit -1" -s eq:-1
-    h_fail "true" -s ne:256
-    h_fail "true" -s ne:-1
+    h_fail "true" -s ne:2147483649
 }
 
 atf_test_case sflag_exit
@@ -88,13 +87,12 @@ sflag_exit_body()
 {
     h_pass 'true' -s exit:0
     h_pass 'false' -s not-exit:0
-    h_pass 'exit 255' -s exit:255
+    h_pass 'exit 2147483647' -s exit:2147483647
     h_pass 'exit 0' -s not-exit:255
 
-    h_fail 'exit 256' -s exit:256
+    h_fail 'exit 2147483648' -s exit:2147483648
     h_fail 'exit -1' -s exit:-1
-    h_fail 'true' -s not-exit:256
-    h_fail 'true' -s not-exit:-1
+    h_fail 'true' -s not-exit:2147483649
 
     h_pass 'true' -s exit
     h_pass 'false' -s exit


### PR DESCRIPTION
All of the platforms we run on have waitid() these days, so switch to it and allow us to capture the full 32-bits of an exit status.