### PR TITLE
atf-check.cpp: include time.h

### DIFF
--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include <limits.h>
 #include <signal.h>
 #include <stdint.h>
+#include <time.h>
 #include <unistd.h>
 }
 


### PR DESCRIPTION
Fixes build error with gcc 14 as reported by the buildroot autobuilders: https://autobuild.buildroot.net/results/41b/41b25ee8e66e34323eca011e4b5fe479ece9ed76/build-end.log

atf-sh/atf-check.cpp: In function 'useconds_t get_monotonic_useconds()':
atf-sh/atf-check.cpp:183:24: error: 'CLOCK_MONOTONIC' was not declared in this scope