### PR TITLE
Address scan-build reported issues

### DIFF
--- a/atf-c/detail/fs.c
+++ b/atf-c/detail/fs.c
@@ -175,16 +175,12 @@ atf_error_t
 copy_contents(const atf_fs_path_t *p, char **buf)
 {
     atf_error_t err;
-    char *str;
 
-    str = (char *)malloc(atf_dynstr_length(&p->m_data) + 1);
-    if (str == NULL)
+    *buf = strdup(atf_fs_path_cstring(p));
+    if (*buf == NULL)
         err = atf_no_memory_error();
-    else {
-        strcpy(str, atf_dynstr_cstring(&p->m_data));
-        *buf = str;
+    else
         err = atf_no_error();
-    }
 
     return err;
 }
@@ -795,10 +791,8 @@ atf_fs_mkdtemp(atf_fs_path_t *p)
     atf_error_t err;
     char *buf;
 
-    if (!check_umask(S_IRWXU, S_IRWXU)) {
-        err = invalid_umask_error(p, atf_fs_stat_dir_type, current_umask());
-        goto out;
-    }
+    if (!check_umask(S_IRWXU, S_IRWXU))
+        return invalid_umask_error(p, atf_fs_stat_dir_type, current_umask());
 
     err = copy_contents(p, &buf);
     if (atf_is_error(err))
@@ -806,14 +800,13 @@ atf_fs_mkdtemp(atf_fs_path_t *p)
 
     err = do_mkdtemp(buf);
     if (atf_is_error(err))
-        goto out_buf;
+        goto out;
 
     replace_contents(p, buf);
 
     INV(!atf_is_error(err));
-out_buf:
-    free(buf);
 out:
+    free(buf);
     return err;
 }
 
@@ -824,10 +817,8 @@ atf_fs_mkstemp(atf_fs_path_t *p, int *fdout)
     char *buf;
     int fd;
 
-    if (!check_umask(S_IRWXU, S_IRWXU)) {
-        err = invalid_umask_error(p, atf_fs_stat_reg_type, current_umask());
-        goto out;
-    }
+    if (!check_umask(S_IRWXU, S_IRWXU))
+        return invalid_umask_error(p, atf_fs_stat_reg_type, current_umask());
 
     err = copy_contents(p, &buf);
     if (atf_is_error(err))
@@ -835,15 +826,14 @@ atf_fs_mkstemp(atf_fs_path_t *p, int *fdout)
 
     err = do_mkstemp(buf, &fd);
     if (atf_is_error(err))
-        goto out_buf;
+        goto out;
 
     replace_contents(p, buf);
     *fdout = fd;
 
     INV(!atf_is_error(err));
-out_buf:
-    free(buf);
 out:
+    free(buf);
     return err;
 }
 

--- a/atf-c/detail/process.c
+++ b/atf-c/detail/process.c
@@ -659,7 +659,7 @@ atf_process_exec_list(atf_process_status_t *s,
 
     err = atf_process_exec_array(s, prog, argv2, outsb, errsb, prehook);
 
-    free(argv2);
 out:
+    free(argv2);
     return err;
 }

--- a/atf-c/detail/sanity_test.c
+++ b/atf-c/detail/sanity_test.c
@@ -85,6 +85,8 @@ do_test_child(void *v)
     exit(EXIT_SUCCESS);
 }
 
+#define	MAX_LINES	3
+
 static
 void
 do_test(enum type t, bool cond)
@@ -92,7 +94,7 @@ do_test(enum type t, bool cond)
     atf_process_child_t child;
     atf_process_status_t status;
     int nlines;
-    char *lines[3];
+    char *lines[MAX_LINES] = { 0 };
 
     {
         atf_process_stream_t outsb, errsb;
@@ -106,16 +108,17 @@ do_test(enum type t, bool cond)
     }
 
     nlines = 0;
-    while (nlines < 3 && (lines[nlines] =
+    while (nlines < MAX_LINES && (lines[nlines] =
            atf_utils_readline(atf_process_child_stderr(&child))) != NULL)
         nlines++;
-    ATF_REQUIRE(nlines == 0 || nlines == 3);
 
     RE(atf_process_child_wait(&child, &status));
     if (!cond) {
+        ATF_REQUIRE(nlines == MAX_LINES);
         ATF_REQUIRE(atf_process_status_signaled(&status));
         ATF_REQUIRE(atf_process_status_termsig(&status) == SIGABRT);
     } else {
+        ATF_REQUIRE(nlines == 0);
         ATF_REQUIRE(atf_process_status_exited(&status));
         ATF_REQUIRE(atf_process_status_exitstatus(&status) == EXIT_SUCCESS);
     }

--- a/atf-c/detail/tp_main.c
+++ b/atf-c/detail/tp_main.c
@@ -198,8 +198,10 @@ params_fini(struct params *p)
     atf_map_fini(&p->m_config);
     atf_fs_path_fini(&p->m_resfile);
     atf_fs_path_fini(&p->m_srcdir);
-    if (p->m_tcname != NULL)
+    if (p->m_tcname != NULL) {
         free(p->m_tcname);
+        p->m_tcname = NULL;
+    }
 }
 
 static


### PR DESCRIPTION
This change addresses several memory access issues cited by scan-build.

- Clean up memory at an appropriate scope after use to avoid complexity with memory management.
- Don't try accessing memory in `do_test` which could be out of bounds, as both 0 and 3 lines could be returned in the function prior to this change.

Relates to: #77 