### PR TITLE
atf-check_test: fix CI runs

### DIFF
--- a/atf-c/detail/process_test.c
+++ b/atf-c/detail/process_test.c
@@ -667,6 +667,15 @@ ATF_TC_BODY(status_coredump, tc)
         atf_tc_skip("Cannot unlimit the core file size; check limits "
                     "manually");
 
+#if defined(__APPLE__)
+    /*
+     * The default security policy on macOS prevents this check from being
+     * tested (coredumps aren't generated for unsigned binaries).
+     */
+    atf_tc_expect_fail(
+        "atf_process_status_coredump check fails on macOS");
+#endif
+
     siginfo_t info;
     fork_and_wait_child(child_sigquit, &info);
     atf_process_status_t s;

--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -208,12 +208,12 @@ parse_exit_code(const std::string& str)
 {
     try {
         const int value = atf::text::to_type< int >(str);
-        if (value < INT_MIN || value > INT_MAX)
-            throw std::runtime_error("Unused reason");
+        if (value < 0 || value > 255)
+            throw std::range_error("Unused reason");
         return value;
-    } catch (const std::runtime_error&) {
+    } catch (const std::range_error&) {
         throw atf::application::usage_error("Invalid exit code for -s option; "
-            "must be an integer in range [%d, %d]", INT_MIN, INT_MAX);
+            "must be an integer in the range [0, 255]");
     }
 }
 

--- a/atf-sh/atf-check_test.sh
+++ b/atf-sh/atf-check_test.sh
@@ -70,12 +70,13 @@ sflag_eq_ne_body()
 {
     h_pass "true" -s eq:0
     h_pass "false" -s ne:0
-    h_pass "exit 2147483647" -s eq:2147483647
+    h_pass "exit 255" -s eq:255
     h_pass "exit 0" -s ne:255
 
-    h_fail "exit 2147483648" -s eq:2147483648
+    h_fail "exit 256" -s eq:256
     h_fail "exit -1" -s eq:-1
-    h_fail "true" -s ne:2147483649
+    h_fail "true" -s ne:256
+    h_fail "true" -s ne:-1
 }
 
 atf_test_case sflag_exit
@@ -87,12 +88,13 @@ sflag_exit_body()
 {
     h_pass 'true' -s exit:0
     h_pass 'false' -s not-exit:0
-    h_pass 'exit 2147483647' -s exit:2147483647
+    h_pass 'exit 255' -s exit:255
     h_pass 'exit 0' -s not-exit:255
 
-    h_fail 'exit 2147483648' -s exit:2147483648
+    h_fail 'exit 256' -s exit:256
     h_fail 'exit -1' -s exit:-1
-    h_fail 'true' -s not-exit:2147483649
+    h_fail 'true' -s not-exit:256
+    h_fail 'true' -s not-exit:-1
 
     h_pass 'true' -s exit
     h_pass 'false' -s exit


### PR DESCRIPTION
Changes:
- Revert changes made to `atf-check` with respect to `-s` and the respective tests made in 20cd4099f57168b7e732a3.
- Expect `:status_coredump` to fail on macOS due to the default security policy in the OS.