### PR TITLE
Update the images referenced in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,15 +4,21 @@ env:
 
 task:
   matrix:
-    - name: 14.0-CURRENT
+    - name: 16.0-CURRENT
       freebsd_instance:
-        image_family: freebsd-14-0-snap
-    - name: 13.0-STABLE
+        image_family: freebsd-16-0-snap
+    - name: 15-STABLE
       freebsd_instance:
-        image_family: freebsd-13-0-snap
-    - name: 13.0-RELEASE
+        image_family: freebsd-15-0-amd64-ufs-snap
+    - name: 15.0-RELEASE
       freebsd_instance:
-        image_family: freebsd-13-0
+        image_family: freebsd-15-0-amd64-ufs
+    - name: 14-STABLE
+      freebsd_instance:
+        image_family: freebsd-14-3-snap
+    - name: 14.3-RELEASE
+      freebsd_instance:
+        image_family: freebsd-14-3
   install_script:
     - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
     - ASSUME_ALWAYS_YES=yes pkg bootstrap -f

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,8 @@ installcheck-kyua:
 	    cd $(pkgtestsdir) && $(TESTS_ENVIRONMENT) \
 		    $(KYUA) --config='$(KYUA_TEST_CONFIG_FILE)' \
 		    report-junit --output="$$JUNIT_OUTPUT"; \
-		    sed -i'' 's/encoding="iso-8859-1"/encoding="utf-8"/' "$$JUNIT_OUTPUT"; \
+	    sed -i '.orig' 's/encoding="iso-8859-1"/encoding="utf-8"/' "$$JUNIT_OUTPUT"; \
+	    rm -f "$$JUNIT_OUTPUT.orig"; \
 	fi; \
 	cd $(pkgtestsdir) && $(TESTS_ENVIRONMENT) \
 		$(KYUA) --config='$(KYUA_TEST_CONFIG_FILE)' report --verbose; \


### PR DESCRIPTION
Replace the 14.0-CURRENT/13.x-STABLE images with supported versions of 14.x, 15.x, and 16.0-CURRENT.