### PR TITLE
Introduce sanitizer options and run with sanitizer on Linux/macOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,8 @@ permissions:
 
 jobs:
     build:
-        name: build ${{ matrix.build-os }} ${{ matrix.compiler }}
+        # yamllint disable-line rule:line-length
+        name: ${{ matrix.build-os }} ${{ matrix.compiler }} ${{ join(matrix.sanitize, '+') }}
         env:
             AR: ${{ matrix.llvm-bindir }}/llvm-ar
             CC: ${{ matrix.llvm-bindir }}/clang
@@ -37,7 +38,8 @@ jobs:
             STRIP: ${{ matrix.llvm-bindir }}/llvm-strip
             ATF_SRCDIR: ${{ github.workspace }}/src
             ATF_OBJDIR: ${{ github.workspace }}/obj
-            JOB_NAME: ${{ matrix.build-os }} ${{ matrix.compiler }}
+            # yamllint disable-line rule:line-length
+            JOB_NAME: ${{ matrix.build-os }} ${{ matrix.compiler }} ${{ join(matrix.sanitize, '+') }}
         runs-on: "${{ matrix.build-os }}"
         strategy:
             fail-fast: false
@@ -66,6 +68,11 @@ jobs:
                           - libtool
                           - pkgconf
                       llvm-bindir: /usr/lib/llvm-18/bin
+                sanitize:
+                    - ""
+                    - ["asan", "lsan"]
+                    - ubsan
+
         steps:
             - name: Install packages (macOS)
               if: runner.os == 'macOS'
@@ -88,17 +95,14 @@ jobs:
                   which -a kyua
             - name: Build
               run: |
-                  echo "uname -a: $(uname -a)"
-                  echo "uname -m: $(uname -m)"
-                  echo "uname -p: $(uname -p)"
-                  echo "Build environment:"
-                  kyua about | head -1
-
                   cd "${ATF_SRCDIR}"
                   ./admin/ci-build/01_configure.sh
             - name: Distcheck (builds and tests)
               run: |
                   CFG_ARGS="--disable-dependency-tracking --enable-developer"
+                  for i in ${{ join(matrix.sanitize, ' ') }}; do
+                      CFG_ARGS="${CFG_OPTS} --enable-${i}"
+                  done
                   cd "${ATF_SRCDIR}"
                   env "EXTRA_DISTCHECK_CONFIGURE_ARGS=${CFG_ARGS}" \
                       ./admin/ci-build/02_distcheck.sh

--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,8 @@ EXTRA_DIST += $(doc_DATA) INSTALL.md README.md
 #
 
 TESTS_ENVIRONMENT = PATH=$(prefix)/bin:$${PATH} \
+                    ASAN_OPTIONS=detect_leaks=1 \
+                    UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
                     PKG_CONFIG_PATH=$(prefix)/lib/pkgconfig
 
 # Allow the caller to override the configuration file to passed to our

--- a/atf-c++/Makefile.am.inc
+++ b/atf-c++/Makefile.am.inc
@@ -61,6 +61,8 @@ atf-c++/atf-c++.pc: $(srcdir)/atf-c++/atf-c++.pc.in Makefile
 	    -e 's#__CXX__#$(ATF_BUILD_CXX)#g' \
 	    -e 's#__INCLUDEDIR__#$(includedir)#g' \
 	    -e 's#__LIBDIR__#$(libdir)#g' \
+	    -e 's#__PC_CXXFLAGS__#$(pc_cxxflags)#g' \
+	    -e 's#__PC_LDFLAGS__#$(pc_ldflags)#g' \
 	    <$(srcdir)/atf-c++/atf-c++.pc.in >atf-c++/atf-c++.pc.tmp; \
 	mv atf-c++/atf-c++.pc.tmp atf-c++/atf-c++.pc
 

--- a/atf-c++/atf-c++.pc.in
+++ b/atf-c++/atf-c++.pc.in
@@ -7,5 +7,5 @@ libdir=__LIBDIR__
 Name: atf-c++
 Description: Automated Testing Framework (C++ binding)
 Version: __ATF_VERSION__
-Cflags: -I${includedir}
-Libs: -L${libdir} -latf-c++ -latf-c
+Cflags: -I${includedir} __PC_CXXFLAGS__
+Libs: -L${libdir} -latf-c++ -latf-c __PC_LDFLAGS__

--- a/atf-c/Makefile.am.inc
+++ b/atf-c/Makefile.am.inc
@@ -74,6 +74,8 @@ atf-c/atf-c.pc: $(srcdir)/atf-c/atf-c.pc.in Makefile
 	    -e 's#__CC__#$(ATF_BUILD_CC)#g' \
 	    -e 's#__INCLUDEDIR__#$(includedir)#g' \
 	    -e 's#__LIBDIR__#$(libdir)#g' \
+	    -e 's#__PC_CFLAGS__#$(pc_cflags)#g' \
+	    -e 's#__PC_LDFLAGS__#$(pc_ldflags)#g' \
 	    <$(srcdir)/atf-c/atf-c.pc.in >atf-c/atf-c.pc.tmp; \
 	mv atf-c/atf-c.pc.tmp atf-c/atf-c.pc
 

--- a/atf-c/atf-c.pc.in
+++ b/atf-c/atf-c.pc.in
@@ -7,5 +7,5 @@ libdir=__LIBDIR__
 Name: atf-c
 Description: Automated Testing Framework (C binding)
 Version: __ATF_VERSION__
-Cflags: -I${includedir}
-Libs: -L${libdir} -latf-c
+Cflags: -I${includedir} __PC_CFLAGS__
+Libs: -L${libdir} -latf-c __PC_LDFLAGS__

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,60 @@ AM_INIT_AUTOMAKE([1.9 check-news foreign subdir-objects -Wall])
 AM_PROG_AR
 LT_INIT
 
+pc_cflags=
+pc_cxxflags=
+pc_ldflags=
+
+AC_ARG_ENABLE([asan],
+AS_HELP_STRING([--enable-asan], [Turn on AddressSanitizer]),,
+[enable_asan=no])
+
+if test "${enable_asan}" = yes; then
+    AC_MSG_NOTICE([building with AddressSanitizer (ASAN)])
+    enable_developer=yes
+    CFLAGS="${CFLAGS} -fsanitize=address"
+    pc_cflags="${pc_cflags} -fsanitize=address"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+    pc_cxxflags="${pc_cxxflags} -fsanitize=address"
+    LDFLAGS="${LDFLAGS} -fsanitize=address"
+    pc_ldflags="${pc_ldflags} -fsanitize=address"
+fi
+
+AC_ARG_ENABLE([lsan],
+AS_HELP_STRING([--enable-lsan], [Turn on LeakSanitizer]),,
+[enable_lsan=no])
+
+if test "${enable_lsan}" = yes; then
+    AC_MSG_NOTICE([building with LeakSanitizer (LSAN)])
+    enable_developer=yes
+    CFLAGS="${CFLAGS} -fsanitize=leak"
+    pc_cflags="${pc_cflags} -fsanitize=leak"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=leak"
+    pc_cxxflags="${pc_cxxflags} -fsanitize=leak"
+    LDFLAGS="${LDFLAGS} -fsanitize=leak"
+    pc_ldflags="${pc_ldflags} -fsanitize=leak"
+fi
+
+AC_ARG_ENABLE([ubsan],
+AS_HELP_STRING([--enable-ubsan], [Turn on UndefinedBehaviourSanitizer]),,
+[enable_ubsan=no])
+
+if test "${enable_ubsan}" = yes; then
+    AC_MSG_NOTICE([building with UndefinedBehaviourSanitizer (UBSAN)])
+    enable_developer=yes
+    CFLAGS="${CFLAGS} -fsanitize=undefined"
+    pc_cflags="${pc_cflags} -fsanitize=undefined"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=undefined"
+    pc_cxxflags="${pc_cxxflags} -fsanitize=undefined"
+    LDFLAGS="${LDFLAGS} -fsanitize=undefined"
+    pc_ldflags="${pc_ldflags} -fsanitize=undefined"
+fi
+
+AC_SUBST([pc_cflags])
+AC_SUBST([pc_cxxflags])
+AC_SUBST([pc_ldflags])
+
+
 dnl -----------------------------------------------------------------------
 dnl Check for the C and C++ compilers and required features.
 dnl -----------------------------------------------------------------------

--- a/m4/developer-mode.m4
+++ b/m4/developer-mode.m4
@@ -55,8 +55,8 @@ AC_DEFUN([KYUA_DEVELOPER_MODE], [
     AC_ARG_ENABLE(
         [developer],
         AS_HELP_STRING([--enable-developer], [enable developer features]),,
-        [if test -d ${srcdir}/.git; then
-             AC_MSG_NOTICE([building from HEAD; developer mode autoenabled])
+        [if test -d "${srcdir}/.git"; then
+             AC_MSG_NOTICE([building from HEAD (developer mode auto-enabled)])
              enable_developer=yes
          else
              enable_developer=no
@@ -70,8 +70,7 @@ AC_DEFUN([KYUA_DEVELOPER_MODE], [
     #                   Mac OS X.  This is due to the way _IOR is defined.
     #
 
-    try_c_cxx_flags="-D_FORTIFY_SOURCE=2 \
-                     -Wall \
+    try_c_cxx_flags="-Wall \
                      -Wcast-qual \
                      -Wextra \
                      -Wpointer-arith \
@@ -81,6 +80,11 @@ AC_DEFUN([KYUA_DEVELOPER_MODE], [
                      -Wsign-compare \
                      -Wswitch \
                      -Wwrite-strings"
+
+    # -D_FORTIFY_SOURCE doesn't play well with ASAN/LSAN.
+    if test "${enable_asan}" = no && test "${enable_lsan}" = no; then
+        try_c_cxx_flags="${try_c_cxx_flags} -D_FORTIFY_SOURCE=2"
+    fi
 
     try_c_flags="-Wmissing-prototypes \
                  -Wno-traditional \
@@ -97,10 +101,12 @@ AC_DEFUN([KYUA_DEVELOPER_MODE], [
                    -Wsign-promo \
                    -Wsynth"
 
-    if test ${enable_developer} = yes; then
+    if test "${enable_developer}" = yes; then
+        AC_MSG_NOTICE([Developer mode enabled])
         try_werror=yes
         try_c_cxx_flags="${try_c_cxx_flags} -g -Werror"
     else
+        AC_MSG_NOTICE([Developer mode disabled])
         try_werror=no
         try_c_cxx_flags="${try_c_cxx_flags} -DNDEBUG"
     fi


### PR DESCRIPTION
Clang has excellent sanitizers, that are very well supported under macOS and Linux. Add AddressSanitizer, LeakSanitizer and UndefinedBehaviourSanitizer configure options to pass the appropriate flags to ${CC}, ${CXX}, etc.

Introduce GH action to run the tests with the sanitizers enabled.