### PR TITLE
Unbreak CI on master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
             OBJDUMP: ${{ matrix.llvm-bindir }}/llvm-objdump
             STRIP: ${{ matrix.llvm-bindir }}/llvm-strip
             ATF_SRCDIR: ${{ github.workspace }}/src
-            ATF_OBJDIR: ${{ github.workspace }}/src
+            ATF_OBJDIR: ${{ github.workspace }}/obj
             JOB_NAME: ${{ matrix.build-os }} ${{ matrix.compiler }}
         runs-on: "${{ matrix.build-os }}"
         strategy:
@@ -109,7 +109,11 @@ jobs:
                   (
                     cd "${REPORTS_DIR}"
                     mkdir -p build_logs
-                    cp -a "${ATF_SRCDIR}"/atf-*/_build/sub/*.log build_logs/
+                    # Gather the distcheck failure log if the target failed.
+                    # It's easier to ignore the failure than create yet another
+                    # conditional variable step.
+                    cp -a "${ATF_SRCDIR}"/atf-*/_build/sub/*.log build_logs/ \
+                        2>/dev/null || true
                     # Include the raw kyua logs.
                     cp -a ~/.kyua/logs kyua_logs
                   )

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 # Major changes between releases
 
+## Changes in version 0.24
+
+Released on MM, DD, 2026
+
 ## Changes in version 0.23
 
 Released on March, 29, 2025


### PR DESCRIPTION
- Add a dummy 0.24 entry to NEWS to unbreak `make distcheck`.
- Fix distcheck log capture in the event CI succeeds.