### PR TITLE
CI workflow cleanup fixes (part 2)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,7 +41,8 @@ task:
     - pkg install -y autoconf automake libtool kyua pkgconf
   script:
     - ./admin/ci-build/01_configure.sh
-    - env JUNIT_OUTPUT="$(pwd)/test-results.xml"
+    - env EXTRA_DISTCHECK_CONFIGURE_ARGS="--enable-developer"
+          JUNIT_OUTPUT="$(pwd)/test-results.xml"
           ./admin/ci-build/02_distcheck.sh
   on_failure:
     dump_distcheck_logs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,7 +100,7 @@ jobs:
               run: |
                   CFG_ARGS="--disable-dependency-tracking --enable-developer"
                   cd "${ATF_SRCDIR}"
-                  env "EXTRA_DISTCONFIGURE_ARGS=${CFG_ARGS}" \
+                  env "EXTRA_DISTCHECK_CONFIGURE_ARGS=${CFG_ARGS}" \
                       ./admin/ci-build/02_distcheck.sh
             - name: Gather/Archive Logs and Reports
               run: |

--- a/admin/ci-build/02_distcheck.sh
+++ b/admin/ci-build/02_distcheck.sh
@@ -22,11 +22,11 @@ f="${f} ATF_BUILD_CXX='${CXX}'"
 if [ -e "$(dirname "$(dirname "$0")")/.git" ]; then
     f="${f} --enable-developer"
 fi
-if [ -n "${EXTRA_DISTCONFIGURE_ARGS:-}" ]; then
-    f="${f} ${EXTRA_DISTCONFIGURE_ARGS}"
+if [ -n "${EXTRA_DISTCHECK_CONFIGURE_ARGS:-}" ]; then
+    f="${f} ${EXTRA_DISTCHECK_CONFIGURE_ARGS}"
 fi
 
-kyua_conf="$(realpath "$(mktemp kyua-XXXXXXXX.conf)")"
+kyua_conf="$(realpath "$(mktemp kyuaconf-XXXXXXXX)")"
 trap 'rm -f "${kyua_conf}"' EXIT INT TERM
 
 sudo=


### PR DESCRIPTION
- Fix typos related to `EXTRA_DISTCHECK_CONFIGURE_ARGS`.
- Fix typo in specifying the temporary kyua config to avoid possible collisions with the filenames.

Fixes:  cf0b307b1d5193e ("CI workflow cleanup")