### PR TITLE
atf-check.1: Add missing -r flag to synopsis

### DIFF
--- a/atf-sh/atf-check.1
+++ b/atf-sh/atf-check.1
@@ -22,7 +22,7 @@
 .\" IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 .\" OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 .\" IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.Dd February 6, 2021
+.Dd January 19, 2026
 .Dt ATF-CHECK 1
 .Os
 .Sh NAME
@@ -34,6 +34,7 @@
 .Op Fl o Ar action:arg ...
 .Op Fl e Ar action:arg ...
 .Op Fl x
+.Op Fl r Ar timeout[:interval]
 .Ar command
 .Sh DESCRIPTION
 .Nm


### PR DESCRIPTION
Fixes:	d7c7c53 ("Add -r timeout[:interval] option to atf-check.")