### PR TITLE
Remove sys/mount.h include

### DIFF
--- a/atf-c++/detail/fs.cpp
+++ b/atf-c++/detail/fs.cpp
@@ -32,7 +32,6 @@
 extern "C" {
 #include <sys/param.h>
 #include <sys/types.h>
-#include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <dirent.h>

--- a/atf-c/detail/fs.c
+++ b/atf-c/detail/fs.c
@@ -31,7 +31,6 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
-#include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 


### PR DESCRIPTION
This include is unused. Remove it to unbreak the build on some platforms, e.g., GNU Hurd.

Obtained from:	Ubuntu Linux [1]
Co-Authored-By:	Andrej Shadura <andrewsh@debian.org>
Signed-off-by:	Enji Cooper <ngie@FreeBSD.org>

Refs:
1. https://git.launchpad.net/ubuntu/+source/atf/tree/debian/patches/0002-Support-GNU-Hurd.patch