### PR TITLE
atf-c.3: Fix test case addition in ATF_TP_ADD_TCS synopsis example

### DIFF
--- a/atf-c/atf-c.3
+++ b/atf-c/atf-c.3
@@ -249,9 +249,9 @@ ATF_TC_BODY(tc3, tc)
 
 ATF_TP_ADD_TCS(tp)
 {
-    ATF_TP_ADD_TC(tcs, tc1);
-    ATF_TP_ADD_TC(tcs, tc2);
-    ATF_TP_ADD_TC(tcs, tc3);
+    ATF_TP_ADD_TC(tp, tc1);
+    ATF_TP_ADD_TC(tp, tc2);
+    ATF_TP_ADD_TC(tp, tc3);
     ... add additional test cases ...
 
     return atf_no_error();


### PR DESCRIPTION
Fixed small typo in which the ATF_TP_ADD_TC argument didn't match the one in ATF_TP_ADD_TCS