### PR TITLE
SPDX license identifiers to atf-c

### DIFF
--- a/atf-c/atf_c_test.c
+++ b/atf-c/atf_c_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/build.c
+++ b/atf-c/build.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2009 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2009 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/build.h
+++ b/atf-c/build.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2009 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2009 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/build_test.c
+++ b/atf-c/build_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2009 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2009 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/check.c
+++ b/atf-c/check.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/check.h
+++ b/atf-c/check.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/check_test.c
+++ b/atf-c/check_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/dynstr.c
+++ b/atf-c/detail/dynstr.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/dynstr.h
+++ b/atf-c/detail/dynstr.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/dynstr_test.c
+++ b/atf-c/detail/dynstr_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/env.c
+++ b/atf-c/detail/env.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2007 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/env.h
+++ b/atf-c/detail/env.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/env_test.c
+++ b/atf-c/detail/env_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2007 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/fs.c
+++ b/atf-c/detail/fs.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2007 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/fs.h
+++ b/atf-c/detail/fs.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/fs_test.c
+++ b/atf-c/detail/fs_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2007 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/list.c
+++ b/atf-c/detail/list.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/list.h
+++ b/atf-c/detail/list.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/list_test.c
+++ b/atf-c/detail/list_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/map.c
+++ b/atf-c/detail/map.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/map.h
+++ b/atf-c/detail/map.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/map_test.c
+++ b/atf-c/detail/map_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/process.c
+++ b/atf-c/detail/process.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2007 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/process.h
+++ b/atf-c/detail/process.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/process_helpers.c
+++ b/atf-c/detail/process_helpers.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/process_test.c
+++ b/atf-c/detail/process_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/sanity.c
+++ b/atf-c/detail/sanity.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/sanity.h
+++ b/atf-c/detail/sanity.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/sanity_test.c
+++ b/atf-c/detail/sanity_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/test_helpers.c
+++ b/atf-c/detail/test_helpers.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/test_helpers.h
+++ b/atf-c/detail/test_helpers.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/text.c
+++ b/atf-c/detail/text.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/text.h
+++ b/atf-c/detail/text.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/text_test.c
+++ b/atf-c/detail/text_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/tp_main.c
+++ b/atf-c/detail/tp_main.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/user.c
+++ b/atf-c/detail/user.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2007 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/user.h
+++ b/atf-c/detail/user.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2007 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/detail/user_test.c
+++ b/atf-c/detail/user_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2007 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2007 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/error.c
+++ b/atf-c/error.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/error.h
+++ b/atf-c/error.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/error_fwd.h
+++ b/atf-c/error_fwd.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/error_test.c
+++ b/atf-c/error_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/h_build.h
+++ b/atf-c/h_build.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2009 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2009 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/macros.h
+++ b/atf-c/macros.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/macros_h_test.c
+++ b/atf-c/macros_h_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/macros_test.c
+++ b/atf-c/macros_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/tc.c
+++ b/atf-c/tc.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/tc.h
+++ b/atf-c/tc.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/tc_test.c
+++ b/atf-c/tc_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/tp.c
+++ b/atf-c/tp.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/tp.h
+++ b/atf-c/tp.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2008 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2008 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/tp_test.c
+++ b/atf-c/tp_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2010 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2010 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/unused_test.c
+++ b/atf-c/unused_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2012 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2012 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/utils.c
+++ b/atf-c/utils.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2010 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2010 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/utils.h
+++ b/atf-c/utils.h
@@ -1,4 +1,6 @@
-/* Copyright (c) 2010 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2010 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/atf-c/utils_test.c
+++ b/atf-c/utils_test.c
@@ -1,4 +1,6 @@
-/* Copyright (c) 2010 The NetBSD Foundation, Inc.
+/* SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2010 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Add BSD-2-Clause identifiers to atf-c to C-source and header files. This does not comply FreeBSD `style(9)` guidance.