### PR TITLE
docs: fix typo in error.c comment

### DIFF
--- a/atf-c/error.c
+++ b/atf-c/error.c
@@ -32,7 +32,7 @@
 
 #include "atf-c/detail/sanity.h"
 
-/* Theoretically, there can only be a single error intance at any given
+/* Theoretically, there can only be a single error instance at any given
  * point in time, because errors are raised at one point and must be
  * handled immediately.  If another error has to be raised during the
  * handling process, something else has to be done with the previous


### PR DESCRIPTION
## Summary

Fix a single typo in `atf-c/error.c`:

- Line 35: "intance" → "instance" in the error singleton comment

No functional changes — comment only.