### PR TITLE
atf-sh: fix memory leaks

### DIFF
--- a/atf-sh/atf-check.cpp
+++ b/atf-sh/atf-check.cpp
@@ -144,7 +144,7 @@ public:
     {
         close();
         try {
-            remove(*m_path);
+            atf::fs::remove(*m_path);
         } catch (const atf::system_error&) {
             // Ignore deletion errors.
         }

--- a/atf-sh/atf-sh.cpp
+++ b/atf-sh/atf-sh.cpp
@@ -168,11 +168,11 @@ atf_sh::main(void)
                                  "does not exist");
 
     const char** argv = construct_argv(m_shell.str(), m_argc, m_argv);
-    // Don't bother keeping track of the memory allocated by construct_argv:
-    // we are going to exec or die immediately.
 
     const int ret = execv(m_shell.c_str(), const_cast< char** >(argv));
     INV(ret == -1);
+    delete[] argv;  // shut up scan-build.
+
     std::cerr << "Failed to execute " << m_shell.str() << ": "
               << std::strerror(errno) << "\n";
     return EXIT_FAILURE;


### PR DESCRIPTION
- Delete allocated memory when an exec fails.
- Fix theoretical memory leaks when allocating the arguments for exec*.

Closes: #130