### PR TITLE
atf-c++(3): fix memory leaks

### DIFF
--- a/atf-c++/detail/application.cpp
+++ b/atf-c++/detail/application.cpp
@@ -37,6 +37,7 @@ extern "C" {
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <iostream>
 
 extern "C" {
@@ -205,19 +206,8 @@ impl::app::run(int argc, char* const* argv)
     m_argc = argc;
     m_argv = argv;
 
-    m_argv0 = m_argv[0];
-
-    m_prog_name = std::strrchr(m_argv[0], '/');
-    if (m_prog_name == NULL)
-        m_prog_name = m_argv[0];
-    else
-        m_prog_name++;
-
-    // Libtool workaround: if running from within the source tree (binaries
-    // that are not installed yet), skip the "lt-" prefix added to files in
-    // the ".libs" directory to show the real (not temporary) name.
-    if (std::strncmp(m_prog_name, "lt-", 3) == 0)
-        m_prog_name += 3;
+    auto m_prog_filename = std::filesystem::path(m_argv[0]).filename();
+    m_prog_name = m_prog_filename.c_str();
 
     const std::string bug =
         std::string("This is probably a bug in ") + m_prog_name +

--- a/atf-c++/detail/application.hpp
+++ b/atf-c++/detail/application.hpp
@@ -81,7 +81,6 @@ protected:
     int m_argc;
     char* const* m_argv;
 
-    const char* m_argv0;
     const char* m_prog_name;
     std::string m_description;
     std::string m_manpage;

--- a/atf-c++/tests.cpp
+++ b/atf-c++/tests.cpp
@@ -122,13 +122,7 @@ static void
 set_program_name(const char* argv0)
 {
     const std::string program_name = atf::fs::path(argv0).leaf_name();
-    // Libtool workaround: if running from within the source tree (binaries
-    // that are not installed yet), skip the "lt-" prefix added to files in
-    // the ".libs" directory to show the real (not temporary) name.
-    if (program_name.substr(0, 3) == "lt-")
-        Program_Name = program_name.substr(3);
-    else
-        Program_Name = program_name;
+    Program_Name = program_name;
 }
 
 bool

--- a/atf-c++/tests.cpp
+++ b/atf-c++/tests.cpp
@@ -454,9 +454,7 @@ init_tcs(void (*add_tcs)(tc_vector&), tc_vector& tcs,
          const atf::tests::vars_map& vars)
 {
     add_tcs(tcs);
-    for (tc_vector::iterator iter = tcs.begin(); iter != tcs.end(); iter++) {
-        impl::tc* tc = *iter;
-
+    for (auto& tc : tcs) {
         tc->init(vars);
     }
 }
@@ -619,14 +617,15 @@ safe_main(int argc, char** argv, void (*add_tcs)(tc_vector&))
             throw usage_error("Cannot provide more than one test case name");
         INV(argc == 1);
     }
-
     tc_vector tcs;
-    init_tcs(add_tcs, tcs, vars);
-    errcode = lflag ? list_tcs(tcs) : run_tc(tcs, argv[0], resfile);
-    for (tc_vector::iterator iter = tcs.begin(); iter != tcs.end(); iter++) {
-        impl::tc* tc = *iter;
-
-        delete tc;
+    try {
+        init_tcs(add_tcs, tcs, vars);
+        errcode = lflag ? list_tcs(tcs) : run_tc(tcs, argv[0], resfile);
+    } catch (...) {
+        for (auto& tc: tcs) {
+            delete tc;
+        }
+        throw;
     }
 
     return errcode;

--- a/atf-c++/tests.cpp
+++ b/atf-c++/tests.cpp
@@ -609,23 +609,20 @@ safe_main(int argc, char** argv, void (*add_tcs)(tc_vector&))
 
     int errcode;
 
-    tc_vector tcs;
     if (lflag) {
         if (argc > 0)
             throw usage_error("Cannot provide test case names with -l");
-
-        init_tcs(add_tcs, tcs, vars);
-        errcode = list_tcs(tcs);
     } else {
         if (argc == 0)
             throw usage_error("Must provide a test case name");
         else if (argc > 1)
             throw usage_error("Cannot provide more than one test case name");
         INV(argc == 1);
-
-        init_tcs(add_tcs, tcs, vars);
-        errcode = run_tc(tcs, argv[0], resfile);
     }
+
+    tc_vector tcs;
+    init_tcs(add_tcs, tcs, vars);
+    errcode = lflag ? list_tcs(tcs) : run_tc(tcs, argv[0], resfile);
     for (tc_vector::iterator iter = tcs.begin(); iter != tcs.end(); iter++) {
         impl::tc* tc = *iter;
 

--- a/atf-c/detail/tp_main.c
+++ b/atf-c/detail/tp_main.c
@@ -583,12 +583,6 @@ atf_tp_main(int argc, char **argv, atf_error_t (*add_tcs_hook)(atf_tp_t *))
     else
         progname++;
 
-    /* Libtool workaround: if running from within the source tree (binaries
-     * that are not installed yet), skip the "lt-" prefix added to files in
-     * the ".libs" directory to show the real (not temporary) name. */
-    if (strncmp(progname, "lt-", 3) == 0)
-        progname += 3;
-
     exitcode = EXIT_FAILURE; /* Silence GCC warning. */
     err = controlled_main(argc, argv, add_tcs_hook, &exitcode);
     if (atf_is_error(err)) {

--- a/test-programs/srcdir_test.sh
+++ b/test-programs/srcdir_test.sh
@@ -70,16 +70,6 @@ libtool_body()
         atf_check -s eq:1 -o empty -e ignore "${hp}" -r res srcdir_exists
         atf_check -s eq:0 -o ignore -e empty grep "Cannot find datafile" res
     done
-
-    for hp in $(get_helpers c_helpers cpp_helpers); do
-        h=${hp##*/}
-        cp ${hp} tmp
-        cp ${hp} tmp/.libs/lt-${h}
-        atf_check -s eq:0 -o ignore -e ignore -x \
-                  "cd tmp && ./.libs/lt-${h} srcdir_exists"
-        atf_check -s eq:1 -o empty -e ignore "${hp}" -r res srcdir_exists
-        atf_check -s eq:0 -o ignore -e empty grep "Cannot find datafile" res
-    done
 }
 
 atf_test_case sflag


### PR DESCRIPTION
- `impl::app::run`: leverage std::filesystem APIs instead of a handrolled version of basename(3).
- `safe_main`: avoid leaking memory on abnormal termination or in the event a usage error occurred.

Closes #133