### PR TITLE
Prevent use-after-free issues

### DIFF
--- a/atf-c/check.c
+++ b/atf-c/check.c
@@ -348,6 +348,7 @@ atf_check_result_fini(atf_check_result_t *r)
     atf_list_fini(&r->pimpl->m_argv);
 
     free(r->pimpl);
+    r->pimpl = NULL;
 }
 
 const char *

--- a/atf-c/detail/dynstr.c
+++ b/atf-c/detail/dynstr.c
@@ -158,6 +158,7 @@ atf_dynstr_init_ap(atf_dynstr_t *ad, const char *fmt, va_list ap)
         va_end(ap2);
         if (ret < 0) {
             free(ad->m_data);
+            ad->m_data = NULL;
             err = atf_libc_error(errno, "Cannot format string");
             goto out;
         }
@@ -278,6 +279,7 @@ atf_dynstr_fini(atf_dynstr_t *ad)
 {
     INV(ad->m_data != NULL);
     free(ad->m_data);
+    ad->m_data = NULL;
 }
 
 char *

--- a/atf-c/detail/fs.c
+++ b/atf-c/detail/fs.c
@@ -281,6 +281,7 @@ normalize_ap(atf_dynstr_t *d, const char *p, va_list ap)
     else {
         err = normalize(d, str);
         free(str);
+        str = NULL;
     }
 
 out:

--- a/atf-c/detail/list.c
+++ b/atf-c/detail/list.c
@@ -84,8 +84,10 @@ static
 void
 delete_entry(struct list_entry *le)
 {
-    if (le->m_managed)
+    if (le->m_managed) {
         free(le->m_object);
+        le->m_object = NULL;
+    }
 
     free(le);
 }
@@ -204,6 +206,7 @@ atf_list_init(atf_list_t *l)
     leend = new_entry(NULL, false);
     if (leend == NULL) {
         free(lebeg);
+        lebeg = NULL;
         return atf_no_memory_error();
     }
 

--- a/atf-c/detail/map.c
+++ b/atf-c/detail/map.c
@@ -188,7 +188,12 @@ atf_map_init_charpp(atf_map_t *m, const char *const *array)
             }
             ptr++;
 
-            err = atf_map_insert(m, key, strdup(value), true);
+            char *tmp_value = strdup(value);
+            if (tmp_value == NULL) {
+                err = atf_no_memory_error();
+                break;
+            }
+            err = atf_map_insert(m, key, tmp_value, true);
         }
     }
 
@@ -206,9 +211,12 @@ atf_map_fini(atf_map_t *m)
     atf_list_for_each(iter, &m->m_list) {
         struct map_entry *me = atf_list_iter_data(iter);
 
-        if (me->m_managed)
+        if (me->m_managed) {
             free(me->m_value);
+            me->m_value = NULL;
+        }
         free(me->m_key);
+        me->m_key = NULL;
         free(me);
     }
     atf_list_fini(&m->m_list);
@@ -365,8 +373,10 @@ atf_map_insert(atf_map_t *m, const char *key, void *value, bool managed)
         }
     } else {
         me = iter.m_entry;
-        if (me->m_managed)
+        if (me->m_managed) {
             free(me->m_value);
+            me->m_value = NULL;
+        }
 
         INV(strcmp(me->m_key, key) == 0);
         me->m_value = value;

--- a/atf-c/detail/process_test.c
+++ b/atf-c/detail/process_test.c
@@ -163,6 +163,7 @@ capture_stream_fini(void *v)
     }
 
     free(s->m_msg);
+    s->m_msg = NULL;
     atf_process_stream_fini(&s->m_base.m_sb);
 }
 

--- a/atf-c/detail/text.c
+++ b/atf-c/detail/text.c
@@ -56,6 +56,7 @@ atf_text_for_each_word(const char *instr, const char *sep,
     }
 
     free(str);
+    str = NULL;
 out:
     return err;
 }

--- a/atf-c/detail/tp_main.c
+++ b/atf-c/detail/tp_main.c
@@ -198,10 +198,8 @@ params_fini(struct params *p)
     atf_map_fini(&p->m_config);
     atf_fs_path_fini(&p->m_resfile);
     atf_fs_path_fini(&p->m_srcdir);
-    if (p->m_tcname != NULL) {
-        free(p->m_tcname);
-        p->m_tcname = NULL;
-    }
+    free(p->m_tcname);
+    p->m_tcname = NULL;
 }
 
 static

--- a/atf-c/error.c
+++ b/atf-c/error.c
@@ -124,11 +124,13 @@ atf_error_free(atf_error_t err)
 
     freeit = err->m_free;
 
-    if (err->m_data != NULL)
-        free(err->m_data);
+    free(err->m_data);
+    err->m_data = NULL;
 
-    if (freeit)
+    if (freeit) {
         free(err);
+        err = NULL;
+    }
 
     error_on_flight = false;
 }

--- a/atf-c/tc.c
+++ b/atf-c/tc.c
@@ -650,6 +650,7 @@ atf_tc_fini(atf_tc_t *tc)
 {
     atf_map_fini(&tc->pimpl->m_vars);
     free(tc->pimpl);
+    tc->pimpl = NULL;
 }
 
 /*
@@ -811,8 +812,10 @@ atf_tc_set_md_var(atf_tc_t *tc, const char *name, const char *fmt, ...)
 
     if (!atf_is_error(err))
         err = atf_map_insert(&tc->pimpl->m_vars, name, value, true);
-    else
+    else {
         free(value);
+        value = NULL;
+    }
 
     return err;
 }

--- a/atf-c/tp.c
+++ b/atf-c/tp.c
@@ -112,6 +112,7 @@ atf_tp_fini(atf_tp_t *tp)
     atf_list_fini(&tp->pimpl->m_tcs);
 
     free(tp->pimpl);
+    tp->pimpl = NULL;
 }
 
 /*

--- a/atf-c/utils.c
+++ b/atf-c/utils.c
@@ -290,10 +290,13 @@ atf_utils_free_charpp(char **argv)
 {
     char **ptr;
 
-    for (ptr = argv; *ptr != NULL; ptr++)
+    for (ptr = argv; *ptr != NULL; ptr++) {
         free(*ptr);
+        *ptr = NULL;
+    }
 
     free(argv);
+    argv = NULL;
 }
 
 /** Searches for a regexp in a file.


### PR DESCRIPTION
NULL out pointers after they've been freed.

This is being done to avoid/detect potential use-after-free situations.

Closes: #135 