### PR TITLE
atf_map_insert: fix memory leaks

### DIFF
--- a/atf-c/detail/map.c
+++ b/atf-c/detail/map.c
@@ -361,9 +361,11 @@ atf_map_insert(atf_map_t *m, const char *key, void *value, bool managed)
     iter = atf_map_find(m, key);
     if (atf_equal_map_iter_map_iter(iter, atf_map_end(m))) {
         me = new_entry(key, value, managed);
-        if (me == NULL)
+        if (me == NULL) {
             err = atf_no_memory_error();
-        else {
+            if (managed)
+                free(value);
+        } else {
             err = atf_list_append(&m->m_list, me, false);
             if (atf_is_error(err)) {
                 if (managed)

--- a/atf-c/detail/tp_main.c
+++ b/atf-c/detail/tp_main.c
@@ -280,6 +280,8 @@ list_tcs(const atf_tp_t *tp)
 
         atf_utils_free_charpp(vars);
     }
+    free(tcs);
+    tcs = NULL;
 }
 
 /* ---------------------------------------------------------------------


### PR DESCRIPTION
- Fix memory leak when listing testcases.
- Don't leak `value` on `new_entry(..)` failure.

Closes: #137 