### PR TITLE
atf-c/detail/process_test:status_coredump: skip on macOS

### DIFF
--- a/atf-c/detail/process_test.c
+++ b/atf-c/detail/process_test.c
@@ -672,8 +672,11 @@ ATF_TC_BODY(status_coredump, tc)
     /*
      * The default security policy on macOS prevents this check from being
      * tested (coredumps aren't generated for unsigned binaries).
+     *
+     * TODO(ngie,144): this test fails when run locally on my machines, but not
+     * in the GHA container images.
      */
-    atf_tc_expect_fail(
+    atf_tc_skip(
         "atf_process_status_coredump check fails on macOS");
 #endif
 


### PR DESCRIPTION
Skip the testcase on macOS as there isn't a reliable way (yet) for determining whether or not the feature is available and can be used due to the security policy in macOS on newer releases not allowing unsigned binaries to coredump.

Closes: #145