### PR TITLE
atf-check(1): clean up manpage

### DIFF
--- a/atf-sh/atf-check.1
+++ b/atf-sh/atf-check.1
@@ -22,7 +22,7 @@
 .\" IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 .\" OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 .\" IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.Dd January 19, 2026
+.Dd August 13, 2026
 .Dt ATF-CHECK 1
 .Os
 .Sh NAME
@@ -39,7 +39,7 @@
 .Sh DESCRIPTION
 .Nm
 executes a given command and analyzes its results, including
-exit code, stdout and stderr.
+exit code, stdout, and stderr.
 .Pp
 .Bf Em
 Test cases must use
@@ -48,24 +48,27 @@ Test cases must use
 builtin function instead of calling this utility directly.
 .Ef
 .Pp
-In the first synopsis form,
 .Nm
 will execute the provided command and apply checks specified
 by arguments.
-By default it will act as if it was run with
+By default
+.Nm
+acts as if it was run with
 .Fl s
 .Ar exit:0
 .Fl o
 .Ar empty
 .Fl e
 .Ar empty .
-Multiple checks for the same output channel are allowed and, if specified,
-their results will be combined as a logical and (meaning that the output must
-match all the provided checks).
 .Pp
-In the second synopsis form,
-.Nm
-will print information about all supported options and their purpose.
+.Fl o
+.Ar empty
+and
+.Fl e
+.Ar empty
+may be specified multiple times.
+If they are specified multiple times, the checks will be applied to
+the appropriate stream in the order they were provided.
 .Pp
 The following options are available:
 .Bl -tag  -width XqualXvalueXX
@@ -81,11 +84,11 @@ accepted.
 .It Ar ignore
 ignores the exit check.
 .It Ar signal:<value>
-checks that the program exited due to a signal and that the signal that
-terminated it is
+checks that the program exited due to a signal, and (optionally) checks that the
+signal which terminated the process is
 .Va value .
-The signal can be specified both as a number or as a name, or it can also
-be omitted altogether, in which case any signal is accepted.
+The signal can be specified as a number, a name, or it can be omitted
+altogether (in which case any signal is accepted).
 .El
 .Pp
 Most of these checkers can be prefixed by the
@@ -113,7 +116,9 @@ Most of these checkers can be prefixed by the
 .Sq not-
 string, which effectively reverses the check.
 .It Fl e Ar action:arg
-Analyzes standard error (syntax identical to above)
+Analyzes standard error.
+The usage is identical to
+.Fl o .
 .It Fl x
 Executes
 .Ar command


### PR DESCRIPTION
Remove references to "second synopsis" as there's only a single usage mentioned in the manpage.

Clarify wordering around behavior when `-o` and `-e` are specified multiple times.

Make longhand description for -e "portable" in case another option is added in-between in the future.

Closes #140 