### PR TITLE
Add freebsd/pkg as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "externals/freebsd/pkg"]
+	path = externals/freebsd/pkg
+	url = https://github.com/freebsd/pkg.git


### PR DESCRIPTION
This is being done to better ensure that the freebsd/pkg test cases don't regress between ATF releases and that any downstream (consumer) changes which may occur due to API breakage are caught pre-merge.

This submodule is not (yet) linked into the ATF release build process yet: it's merely a developer convenience.