### PR TITLE
Fix additional assorted memory leaks in libatf-c and related utilities

### DIFF
--- a/atf-c/build.c
+++ b/atf-c/build.c
@@ -83,7 +83,7 @@ append_optargs(const char *const optargs[], atf_list_t *argv)
 
     err = atf_no_error();
     while (*optargs != NULL && !atf_is_error(err)) {
-        err = append_arg1(strdup(*optargs), argv);
+        err = append_arg1(*optargs, argv);
         optargs++;
     }
 

--- a/atf-c/detail/dynstr.c
+++ b/atf-c/detail/dynstr.c
@@ -45,22 +45,18 @@ atf_error_t
 resize(atf_dynstr_t *ad, size_t newsize)
 {
     char *newdata;
-    atf_error_t err;
 
     PRE(newsize > ad->m_datasize);
 
-    newdata = (char *)malloc(newsize);
-    if (newdata == NULL) {
-        err = atf_no_memory_error();
-    } else {
-        strcpy(newdata, ad->m_data);
-        free(ad->m_data);
-        ad->m_data = newdata;
-        ad->m_datasize = newsize;
-        err = atf_no_error();
-    }
+    newdata = realloc(ad->m_data, newsize);
+    if (newdata == NULL)
+        return atf_no_memory_error();
 
-    return err;
+    newdata[newsize - 1] = '\0';
+    ad->m_data = newdata;
+    ad->m_datasize = newsize;
+
+    return atf_no_error();
 }
 
 static
@@ -117,21 +113,16 @@ const size_t atf_dynstr_npos = SIZE_MAX;
 atf_error_t
 atf_dynstr_init(atf_dynstr_t *ad)
 {
-    atf_error_t err;
 
-    ad->m_data = (char *)malloc(sizeof(char));
-    if (ad->m_data == NULL) {
-        err = atf_no_memory_error();
-        goto out;
-    }
+    ad->m_data = malloc(sizeof(char));
+    if (ad->m_data == NULL)
+        return atf_no_memory_error();
 
     ad->m_data[0] = '\0';
     ad->m_datasize = 1;
     ad->m_length = 0;
-    err = atf_no_error();
 
-out:
-    return err;
+    return atf_no_error();
 }
 
 atf_error_t

--- a/atf-c/detail/tp_main.c
+++ b/atf-c/detail/tp_main.c
@@ -290,15 +290,17 @@ list_tcs(const atf_tp_t *tp)
 
 static
 atf_error_t
-handle_tcarg(const char *tcarg, char **tcname, enum tc_part *tcpart)
+handle_tcarg(const char *tcarg, char **tcname_out, enum tc_part *tcpart)
 {
-    char *delim;
+    char *delim, *tcname;
 
-    *tcname = strdup(tcarg);
-    if (*tcname == NULL)
+    *tcname_out = NULL;
+    tcname = strdup(tcarg);
+    if (tcname == NULL) {
         return atf_no_memory_error();
+    }
 
-    delim = strchr(*tcname, ':');
+    delim = strchr(tcname, ':');
     if (delim != NULL) {
         *delim = '\0';
 
@@ -312,6 +314,7 @@ handle_tcarg(const char *tcarg, char **tcname, enum tc_part *tcpart)
         }
     }
 
+    *tcname_out = tcname;
     return atf_no_error();
 }
 

--- a/atf-c/tc.c
+++ b/atf-c/tc.c
@@ -648,6 +648,7 @@ atf_tc_init_pack(atf_tc_t *tc, const atf_tc_pack_t *pack,
 void
 atf_tc_fini(atf_tc_t *tc)
 {
+    atf_map_fini(&tc->pimpl->m_config);
     atf_map_fini(&tc->pimpl->m_vars);
     free(tc->pimpl);
     tc->pimpl = NULL;


### PR DESCRIPTION
- atf-c/detail/dynstr.c: simplify `atf_dynstr`'s `resize(..)` internal helper routine by using realloc instead of hand rolling the equivalent.
- atc-c/detail/tp_main.c: modify `handle_tcarg`'s logic to avoid touching an input buffer, potentially leaving the contents of the buffer in a poorly defined state.
- atf-c/build.c: don't leak `optargs` by creating an unnecessary copy with `strdup(..)`.
- atf-c/tc.c: atf_tc_fini: clean up `m_config` on test exit.

This doesn't address the remaining issues noted in #77, but it tackles some of the less complicated items which needed tackling.