### PR TITLE
atf-c/detail/tp_main.c: handle_tc_arg: squash potential memory leak

### DIFF
--- a/atf-c/detail/tp_main.c
+++ b/atf-c/detail/tp_main.c
@@ -310,6 +310,7 @@ handle_tcarg(const char *tcarg, char **tcname_out, enum tc_part *tcpart)
         } else if (strcmp(delim, "cleanup") == 0) {
             *tcpart = CLEANUP;
         } else {
+            free(tcname);
             return usage_error("Invalid test case part `%s'", delim);
         }
     }


### PR DESCRIPTION
In the event an invalid test case "part" specified internally, `tcname` could be leaked when raising a `usage_error`.

This change frees the memory allocated in the function explicitly before the `usage_error` is returned.

Fixes:	26e2d9b ("atf-c: tp_main.c: make memory management slightly less complex")