### PR TITLE
atf-c++: remove atf::text::duplicate

### DIFF
--- a/atf-c++/detail/text.cpp
+++ b/atf-c++/detail/text.cpp
@@ -42,14 +42,6 @@ extern "C" {
 namespace impl = atf::text;
 #define IMPL_NAME "atf::text"
 
-char*
-impl::duplicate(const char* str)
-{
-    char* copy = new char[std::strlen(str) + 1];
-    std::strcpy(copy, str);
-    return copy;
-}
-
 bool
 impl::match(const std::string& str, const std::string& regex)
 {

--- a/atf-c++/detail/text.hpp
+++ b/atf-c++/detail/text.hpp
@@ -39,14 +39,6 @@ namespace atf {
 namespace text {
 
 //!
-//! \brief Duplicates a C string using the new[] allocator.
-//!
-//! Replaces the functionality of strdup by using the new[] allocator and
-//! thus allowing the resulting memory to be managed by utils::auto_array.
-//!
-char* duplicate(const char*);
-
-//!
 //! \brief Joins multiple words into a string.
 //!
 //! Joins a list of words into a string, separating them using the provided

--- a/atf-c++/detail/text_test.cpp
+++ b/atf-c++/detail/text_test.cpp
@@ -35,26 +35,6 @@
 // Test cases for the free functions.
 // ------------------------------------------------------------------------
 
-ATF_TEST_CASE(duplicate);
-ATF_TEST_CASE_HEAD(duplicate)
-{
-    set_md_var("descr", "Tests the duplicate function");
-}
-ATF_TEST_CASE_BODY(duplicate)
-{
-    using atf::text::duplicate;
-
-    const char* orig = "foo";
-
-    char* copy = duplicate(orig);
-    ATF_REQUIRE_EQ(std::strlen(copy), 3);
-    ATF_REQUIRE(std::strcmp(copy, "foo") == 0);
-
-    std::strcpy(copy, "bar");
-    ATF_REQUIRE(std::strcmp(copy, "bar") == 0);
-    ATF_REQUIRE(std::strcmp(orig, "foo") == 0);
-}
-
 ATF_TEST_CASE(join);
 ATF_TEST_CASE_HEAD(join)
 {
@@ -373,7 +353,6 @@ ATF_TEST_CASE_BODY(to_type)
 ATF_INIT_TEST_CASES(tcs)
 {
     // Add the test cases for the free functions.
-    ATF_ADD_TEST_CASE(tcs, duplicate);
     ATF_ADD_TEST_CASE(tcs, join);
     ATF_ADD_TEST_CASE(tcs, match);
     ATF_ADD_TEST_CASE(tcs, split);


### PR DESCRIPTION
This API is not technically used anywhere in the test suite and the code is as leaky as a rusted bucket since it makes no attempt to actually delete memory it allocates in the API.

This API is not in use anywhere in the FreeBSD test suite, and thus is a prime candidate for removal.

Closes:	#152