### PR TITLE
atf_utils_wait: fix memory leaks

### DIFF
--- a/atf-c/utils.c
+++ b/atf-c/utils.c
@@ -472,4 +472,7 @@ atf_utils_wait(const pid_t pid, const int exitstatus, const char *expout,
 
     ATF_REQUIRE(unlink(atf_dynstr_cstring(&out_name)) != -1);
     ATF_REQUIRE(unlink(atf_dynstr_cstring(&err_name)) != -1);
+
+    atf_dynstr_fini(&out_name);
+    atf_dynstr_fini(&err_name);
 }


### PR DESCRIPTION
Free up `err_name` and `out_name` at the end of the function.

These objects were previously leaked whenever the function completed successfully and were cited by LSAN.

Closes:	#162