### PR TITLE
atf-c/detail/map_test.c: map_init_charpp_short: fix memory leak

### DIFF
--- a/atf-c/detail/map_test.c
+++ b/atf-c/detail/map_test.c
@@ -108,6 +108,7 @@ ATF_TC_BODY(map_init_charpp_short, tc)
     atf_error_t err = atf_map_init_charpp(&map, array);
     ATF_REQUIRE(atf_is_error(err));
     ATF_REQUIRE(atf_error_is(err, "libc"));
+    atf_error_free(err);
 }
 
 /*


### PR DESCRIPTION
Call `atf_err_free` when done testing the error to avoid leaking memory.

Closes:	#164