### PR TITLE
Introduce clang sanitizer support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,8 +24,9 @@ permissions:
     contents: read
 
 jobs:
-    build:
-        name: build ${{ matrix.build-os }} ${{ matrix.compiler }}
+    build-and-test:
+        # yamllint disable-line rule:line-length
+        name: ${{ matrix.build-os }} ${{ matrix.compiler }} ${{ join(matrix.sanitize, '+') }}
         env:
             AR: ${{ matrix.llvm-bindir }}/llvm-ar
             CC: ${{ matrix.llvm-bindir }}/clang
@@ -37,7 +38,8 @@ jobs:
             STRIP: ${{ matrix.llvm-bindir }}/llvm-strip
             ATF_SRCDIR: ${{ github.workspace }}/src
             ATF_OBJDIR: ${{ github.workspace }}/obj
-            JOB_NAME: ${{ matrix.build-os }} ${{ matrix.compiler }}
+            # yamllint disable-line rule:line-length
+            JOB_NAME: ${{ matrix.build-os }} ${{ matrix.compiler }} ${{ join(matrix.sanitize, '+') }}
         runs-on: "${{ matrix.build-os }}"
         strategy:
             fail-fast: false
@@ -68,6 +70,15 @@ jobs:
                           - libtool
                           - pkgconf
                       llvm-bindir: /usr/lib/llvm-18/bin
+                exclude:
+                    - build-os: macos-latest
+                      sanitize: ["asan", "lsan"]
+                sanitize:
+                    - ""
+                    # TODO(ngie,77): tests currently fail when these options are enabled.
+                    #- ["asan", "lsan"]
+                    - ubsan
+
         steps:
             - name: Install packages (macOS)
               if: runner.os == 'macOS'
@@ -88,8 +99,12 @@ jobs:
             - name: Sanity checks
               run: |
                   which -a kyua
-            - name: Build
+            - name: Configure
               run: |
+                  CFG_ARGS=""
+                  for i in ${{ join(matrix.sanitize, ' ') }}; do
+                      CFG_ARGS="${CFG_ARGS} --enable-${i}"
+                  done
                   echo "uname -a: $(uname -a)"
                   echo "uname -m: $(uname -m)"
                   echo "uname -p: $(uname -p)"
@@ -97,10 +112,13 @@ jobs:
                   kyua about | head -1
 
                   cd "${ATF_SRCDIR}"
-                  ./admin/ci-build/01_configure.sh
+                  ./admin/ci-build/01_configure.sh ${CFG_ARGS}
             - name: Distcheck (builds and tests)
               run: |
-                  CFG_ARGS="--disable-dependency-tracking --enable-developer"
+                  CFG_ARGS="--disable-dependency-tracking"
+                  for i in ${{ join(matrix.sanitize, ' ') }}; do
+                      CFG_ARGS="${CFG_ARGS} --enable-${i}"
+                  done
                   cd "${ATF_SRCDIR}"
                   env "EXTRA_DISTCHECK_CONFIGURE_ARGS=${CFG_ARGS}" \
                       ./admin/ci-build/02_distcheck.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ script:
 
 - `ATF_BUILD_CC`:
 
-  **Possible values:** empty, an absolute or relative path to a C compiler.
+  **Possible values:** empty, or an absolute or relative path to a C compiler.
 
   **Default:** the value of CC as detected by the configure script.
 
@@ -104,7 +104,7 @@ script:
 
 - `ATF_BUILD_CFLAGS`:
 
-  **Possible values:** empty, a list of valid C compiler flags.
+  **Possible values:** empty, or a list of valid C compiler flags.
 
   **Default:** the value of CFLAGS as detected by the configure script.
 
@@ -113,7 +113,7 @@ script:
 
 - `ATF_BUILD_CPP`:
 
-  **Possible values:** empty, an absolute or relative path to a C/C++
+  **Possible values:** empty, or an absolute or relative path to a C/C++
   preprocessor.
 
   **Default:** the value of CPP as detected by `configure` script.
@@ -123,7 +123,7 @@ script:
 
 - `ATF_BUILD_CPPFLAGS`:
 
-  **Possible values:** empty, a list of valid C/C++ preprocessor flags.
+  **Possible values:** empty, or a list of valid C/C++ preprocessor flags.
 
   **Default:** the value of `CPPFLAGS` as detected by the configure script.
 
@@ -132,7 +132,7 @@ script:
 
 - `ATF_BUILD_CXX`:
 
-  **Possible values:** empty, an absolute or relative path to a C++ compiler.
+  **Possible values:** empty, or an absolute or relative path to a C++ compiler.
 
   **Default:** the value of `CXX` as detected by the configure script.
 
@@ -141,7 +141,7 @@ script:
 
 - `ATF_BUILD_CXXFLAGS`:
 
-  **Possible values:** empty, a list of valid C++ compiler flags.
+  **Possible values:** empty, or a list of valid C++ compiler flags.
 
   **Default:** the value of `CXXFLAGS` as detected by `configure` script.
 
@@ -163,8 +163,6 @@ The following flags are specific to ATF's `configure` script:
 
 - `--enable-developer`:
 
-  **Possible values:** `yes`, `no`
-
   **Default:** `yes` in HEAD builds; `no` in release builds.
 
   Enables several features useful for development, such as the inclusion
@@ -174,3 +172,33 @@ The following flags are specific to ATF's `configure` script:
   The compiler will be executed with an exhaustive collection of warning
   detection features regardless of the value of this flag. However, such
   warnings are only fatal when `--enable-developer` is `yes`.
+
+- `--enable-asan`
+
+  **Default:** `no`.
+
+  Enables ASAN (Address Sanitizer) compiler support in the toolchain.
+
+  Platform-specific support varies depending on the toolchain and OS.
+
+- `--enable-lsan`
+
+  **Default:** `no`.
+
+  Enables LSAN (Leak Sanitizer) compiler support in the toolchain.
+
+  Platform-specific support varies depending on the toolchain and OS.
+
+  **Important:**
+  * llvm support is only available in Linux and macOS at time of writing.
+  * The test suite does not currently pass with this option enabled. See
+    [Issue #77](https://github.com/freebsd/atf/issues/77) for more details.
+
+- `--enable-ubsan`
+
+  **Default:** `no`.
+
+  Enables UBSAN (Undefined Behavior Sanitizier) compiler support in the
+  toolchain.
+
+  Platform-specific support varies depending on the toolchain and OS.

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,22 @@ EXTRA_DIST += $(doc_DATA) INSTALL.md README.md
 TESTS_ENVIRONMENT = PATH=$(prefix)/bin:$${PATH} \
                     PKG_CONFIG_PATH=$(prefix)/lib/pkgconfig
 
+if HAVE_ASAN
+# NB: the trailing comma is intentional. I hate automake not allowing `:=` use on subsequent lines.
+if HAVE_LSAN
+LSAN_OPTIONS = detect_leaks=1,
+else
+LSAN_OPTIONS =
+endif
+# Some of the testcases trigger false positives as they pass
+# `SIZE_MAX - 1`, etc, to malloc(3).
+ASAN_OPTIONS = ${LSAN_OPTIONS}allocator_may_return_null=1
+TESTS_ENVIRONMENT+= ASAN_OPTIONS=${ASAN_OPTIONS}
+endif
+if HAVE_UBSAN
+TESTS_ENVIRONMENT+= UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
+endif
+
 # Allow the caller to override the configuration file to passed to our
 # test runs below.
 KYUA_TEST_CONFIG_FILE = none

--- a/admin/ci-build/01_configure.sh
+++ b/admin/ci-build/01_configure.sh
@@ -15,7 +15,7 @@ fi
 # shellcheck disable=SC2086
 autoreconf ${autoreconf_args}
 
-if ! ./configure; then
+if ! ./configure $*; then
     cat config.log || true
     exit 1
 fi

--- a/atf-c++/Makefile.am.inc
+++ b/atf-c++/Makefile.am.inc
@@ -61,6 +61,8 @@ atf-c++/atf-c++.pc: $(srcdir)/atf-c++/atf-c++.pc.in Makefile
 	    -e 's#__CXX__#$(ATF_BUILD_CXX)#g' \
 	    -e 's#__INCLUDEDIR__#$(includedir)#g' \
 	    -e 's#__LIBDIR__#$(libdir)#g' \
+	    -e 's#__PC_CXXFLAGS__#$(pc_cxxflags)#g' \
+	    -e 's#__PC_LDFLAGS__#$(pc_ldflags)#g' \
 	    <$(srcdir)/atf-c++/atf-c++.pc.in >atf-c++/atf-c++.pc.tmp; \
 	mv atf-c++/atf-c++.pc.tmp atf-c++/atf-c++.pc
 

--- a/atf-c++/atf-c++.pc.in
+++ b/atf-c++/atf-c++.pc.in
@@ -7,5 +7,5 @@ libdir=__LIBDIR__
 Name: atf-c++
 Description: Automated Testing Framework (C++ binding)
 Version: __ATF_VERSION__
-Cflags: -I${includedir}
-Libs: -L${libdir} -latf-c++ -latf-c
+Cflags: -I${includedir} __PC_CXXFLAGS__
+Libs: -L${libdir} -latf-c++ -latf-c __PC_LDFLAGS__

--- a/atf-c/Makefile.am.inc
+++ b/atf-c/Makefile.am.inc
@@ -74,6 +74,8 @@ atf-c/atf-c.pc: $(srcdir)/atf-c/atf-c.pc.in Makefile
 	    -e 's#__CC__#$(ATF_BUILD_CC)#g' \
 	    -e 's#__INCLUDEDIR__#$(includedir)#g' \
 	    -e 's#__LIBDIR__#$(libdir)#g' \
+	    -e 's#__PC_CFLAGS__#$(pc_cflags)#g' \
+	    -e 's#__PC_LDFLAGS__#$(pc_ldflags)#g' \
 	    <$(srcdir)/atf-c/atf-c.pc.in >atf-c/atf-c.pc.tmp; \
 	mv atf-c/atf-c.pc.tmp atf-c/atf-c.pc
 

--- a/atf-c/atf-c.pc.in
+++ b/atf-c/atf-c.pc.in
@@ -7,5 +7,5 @@ libdir=__LIBDIR__
 Name: atf-c
 Description: Automated Testing Framework (C binding)
 Version: __ATF_VERSION__
-Cflags: -I${includedir}
-Libs: -L${libdir} -latf-c
+Cflags: -I${includedir} __PC_CFLAGS__
+Libs: -L${libdir} -latf-c __PC_LDFLAGS__

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,63 @@ AM_INIT_AUTOMAKE([1.9 check-news foreign subdir-objects -Wall])
 AM_PROG_AR
 LT_INIT
 
+pc_cflags=
+pc_cxxflags=
+pc_ldflags=
+
+AC_ARG_ENABLE([asan],
+AS_HELP_STRING([--enable-asan], [Turn on AddressSanitizer]),,
+[enable_asan=no])
+
+if test ${enable_asan} = yes; then
+    AC_MSG_NOTICE([building with AddressSanitizer (ASAN)])
+    enable_developer=yes
+    CFLAGS="${CFLAGS} -fsanitize=address"
+    pc_cflags="${pc_cflags} -fsanitize=address"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=address"
+    pc_cxxflags="${pc_cxxflags} -fsanitize=address"
+    LDFLAGS="${LDFLAGS} -fsanitize=address"
+    pc_ldflags="${pc_ldflags} -fsanitize=address"
+fi
+AM_CONDITIONAL([HAVE_ASAN], [test "${enable_asan}" = yes])
+
+AC_ARG_ENABLE([lsan],
+AS_HELP_STRING([--enable-lsan], [Turn on LeakSanitizer]),,
+[enable_lsan=no])
+
+if test ${enable_lsan} = yes; then
+    AC_MSG_NOTICE([building with LeakSanitizer (LSAN)])
+    enable_developer=yes
+    CFLAGS="${CFLAGS} -fsanitize=leak"
+    pc_cflags="${pc_cflags} -fsanitize=leak"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=leak"
+    pc_cxxflags="${pc_cxxflags} -fsanitize=leak"
+    LDFLAGS="${LDFLAGS} -fsanitize=leak"
+    pc_ldflags="${pc_ldflags} -fsanitize=leak"
+fi
+AM_CONDITIONAL([HAVE_LSAN], [test "${enable_lsan}" = yes])
+
+AC_ARG_ENABLE([ubsan],
+AS_HELP_STRING([--enable-ubsan], [Turn on UndefinedBehaviourSanitizer]),,
+[enable_ubsan=no])
+
+if test ${enable_ubsan} = yes; then
+    AC_MSG_NOTICE([building with UndefinedBehaviourSanitizer (UBSAN)])
+    enable_developer=yes
+    CFLAGS="${CFLAGS} -fsanitize=undefined"
+    pc_cflags="${pc_cflags} -fsanitize=undefined"
+    CXXFLAGS="${CXXFLAGS} -fsanitize=undefined"
+    pc_cxxflags="${pc_cxxflags} -fsanitize=undefined"
+    LDFLAGS="${LDFLAGS} -fsanitize=undefined"
+    pc_ldflags="${pc_ldflags} -fsanitize=undefined"
+fi
+AM_CONDITIONAL([HAVE_UBSAN], [test "${enable_ubsan}" = yes])
+
+AC_SUBST([pc_cflags])
+AC_SUBST([pc_cxxflags])
+AC_SUBST([pc_ldflags])
+
+
 dnl -----------------------------------------------------------------------
 dnl Check for the C and C++ compilers and required features.
 dnl -----------------------------------------------------------------------

--- a/m4/developer-mode.m4
+++ b/m4/developer-mode.m4
@@ -55,11 +55,13 @@ AC_DEFUN([KYUA_DEVELOPER_MODE], [
     AC_ARG_ENABLE(
         [developer],
         AS_HELP_STRING([--enable-developer], [enable developer features]),,
-        [if test -d ${srcdir}/.git; then
-             AC_MSG_NOTICE([building from HEAD; developer mode autoenabled])
+        [if test "x$enable_developer" = x; then
+           if test -d "${srcdir}/.git"; then
+             AC_MSG_NOTICE([building from HEAD (developer mode auto-enabled)])
              enable_developer=yes
-         else
+           else
              enable_developer=no
+           fi
          fi])
 
     #
@@ -70,7 +72,8 @@ AC_DEFUN([KYUA_DEVELOPER_MODE], [
     #                   Mac OS X.  This is due to the way _IOR is defined.
     #
 
-    try_c_cxx_flags="-D_FORTIFY_SOURCE=2 \
+#    try_c_cxx_flags="-D_FORTIFY_SOURCE=2 \
+    try_c_cxx_flags=" \
                      -Wall \
                      -Wcast-qual \
                      -Wextra \
@@ -98,9 +101,11 @@ AC_DEFUN([KYUA_DEVELOPER_MODE], [
                    -Wsynth"
 
     if test ${enable_developer} = yes; then
+        AC_MSG_NOTICE([Developer mode enabled])
         try_werror=yes
         try_c_cxx_flags="${try_c_cxx_flags} -g -Werror"
     else
+        AC_MSG_NOTICE([Developer mode disabled])
         try_werror=no
         try_c_cxx_flags="${try_c_cxx_flags} -DNDEBUG"
     fi


### PR DESCRIPTION
Clang has excellent sanitizers, that are very well supported under Linux and macOS. Add AddressSanitizer, LeakSanitizer and UndefinedBehaviourSanitizer configure options to pass the appropriate flags to ${CC}, ${CXX}, etc.

Introduce GH action to run the tests with UBSAN enabled. Initial scaffolding for ASAN/LSAN support is added, but not enabled via GHA. Issues blocking its enablement are discussed more at length in #77.

Closes:	#168
Closes:	#169
Closes:	#170