### PR TITLE
[CI]: update LLVM from version 19 to 20 on macOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,15 +58,15 @@ jobs:
                     # The macOS runner uses a homebrew provided compiler as the
                     # system compiler lacks ASAN/LSAN/UBSAN support.
                     - build-os: macos-latest
-                      compiler: clang-19
+                      compiler: clang-20
                       pkgs:
                           - autoconf
                           - automake
                           - kyua
                           - libtool
-                          - llvm@19
+                          - llvm@20
                           - pkgconf
-                      llvm-bindir: /opt/homebrew/opt/llvm@19/bin
+                      llvm-bindir: /opt/homebrew/opt/llvm@20/bin
                     - build-os: ubuntu-latest
                       compiler: clang-18
                       pkgs:


### PR DESCRIPTION
This change updates the version of LLVM from 19 to 20 in an attempt to reduce time and waste when spinning up the macOS image.